### PR TITLE
CHK-150 clearing package after trip finish

### DIFF
--- a/app/src/main/java/com/chaikasoft/app/data/room/dao/CartOperationDao.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/dao/CartOperationDao.kt
@@ -28,6 +28,10 @@ interface CartOperationDao {
     @Delete
     suspend fun delete(cartOperation: CartOperation)
 
+    /** Полностью удалить все операции (каскадом удалятся cart_items). */
+    @Query("DELETE FROM cart_operations")
+    suspend fun clearAllOperations()
+
     // Пагинация «шапок» из VIEW
     @Query("""
         SELECT * 

--- a/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomCartOperationRepository.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomCartOperationRepository.kt
@@ -55,4 +55,8 @@ class RoomCartOperationRepository @Inject constructor(
             ),
             pagingSourceFactory = { cartOperationDao.getPagedOperationInfosByType(type.toInt()) }
         ).flow.map { paging -> paging.map { it.toDomain() } }
+
+    override suspend fun clearAllOperations() {
+        cartOperationDao.clearAllOperations()
+    }
 }

--- a/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomCartOperationRepositoryInterface.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomCartOperationRepositoryInterface.kt
@@ -26,4 +26,6 @@ interface RoomCartOperationRepositoryInterface {
         type: OperationTypeDomain,
         pageSize: Int
     ): Flow<PagingData<OperationSummaryDomain>>
+
+    suspend fun clearAllOperations()
 }

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/ConductorTripShiftUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/ConductorTripShiftUseCases.kt
@@ -136,7 +136,8 @@ class CompleteShiftAndSendUseCase @Inject constructor(
 class GenerateShiftReportUseCase @Inject constructor(
     private val shiftRepo: RoomConductorTripShiftRepositoryInterface,
     private val getCartReports: GetCartReportsUseCase,
-    moshi: Moshi
+    moshi: Moshi,
+    private val clearOpsAndPackage: ClearOperationsAndPackageUseCase
 ) {
     private val jsonAdapter = moshi.adapter(ShiftReportReport::class.java)
 
@@ -144,9 +145,9 @@ class GenerateShiftReportUseCase @Inject constructor(
         val shift = shiftRepo.getActiveShift()
             ?: throw IllegalStateException("Active shift with uuid=$uuid not found")
 
-        // Вот здесь стало сразу по делу:
+        // 1) Собираем CartReport'ы из текущих операций (пока они ещё в БД)
         val carts = getCartReports()
-
+        // 2) Формируем итоговый отчёт
         val report = ShiftReportReport(
             tripId     = TripIdReport(shift.trip.trainNumber, shift.trip.departure),
             endTime    = shift.trip.arrival,
@@ -155,7 +156,7 @@ class GenerateShiftReportUseCase @Inject constructor(
                 ?: throw IllegalStateException("Active carriage not set"),
             carts      = carts
         )
-
+        // 3) Фиксируем в БД: статус FINISHED + сам JSON
         val json = jsonAdapter.toJson(report)
         shiftRepo.updateStatusAndReport(
             uuid       = uuid,
@@ -163,6 +164,8 @@ class GenerateShiftReportUseCase @Inject constructor(
             reportJson = json,
             updatedAt  = System.currentTimeMillis()
         )
+        // 4) Сразу же очищаем операции → «пакет» пустой
+        clearOpsAndPackage()
         return json
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/OperationUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/OperationUseCases.kt
@@ -60,3 +60,12 @@ class GetPagedOperationSummariesByTypeUseCase @Inject constructor(
     ): Flow<PagingData<OperationSummaryDomain>> =
         repo.getPagedOperationSummariesByType(type, pageSize)
 }
+
+/** Очистить все операции (и тем самым обнулить «пакет»). */
+class ClearOperationsAndPackageUseCase @Inject constructor(
+    private val cartOpsRepo: RoomCartOperationRepositoryInterface
+) {
+    suspend operator fun invoke() {
+        cartOpsRepo.clearAllOperations()
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Новые возможности
  - После формирования отчёта смены кондуктора все операции корзины и связанный пакет автоматически очищаются, позволяя начинать следующую смену с чистыми данными.
  - Добавлена возможность полной очистки операций корзины на уровне приложения, что упрощает сброс данных и предотвращает накопление устаревшей информации.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->