### PR TITLE
CHK-228 statistic and operations for previous trips

### DIFF
--- a/app/src/main/java/com/chaikasoft/app/di/RoomRepositoriesModule.kt
+++ b/app/src/main/java/com/chaikasoft/app/di/RoomRepositoriesModule.kt
@@ -1,15 +1,5 @@
 package com.chaikasoft.app.di
 
-import com.chaikasoft.app.data.room.AppDatabase
-import com.chaikasoft.app.data.room.dao.CartItemDao
-import com.chaikasoft.app.data.room.dao.CartOperationDao
-import com.chaikasoft.app.data.room.dao.ConductorDao
-import com.chaikasoft.app.data.room.dao.ConductorTripShiftDao
-import com.chaikasoft.app.data.room.dao.FastReportViewDao
-import com.chaikasoft.app.data.room.dao.PackageItemViewDao
-import com.chaikasoft.app.data.room.dao.ProductInfoDao
-import com.chaikasoft.app.data.room.dao.StationDao
-import com.chaikasoft.app.data.room.dao.SyncMetaDao
 import com.chaikasoft.app.data.room.repo.RoomCartItemRepository
 import com.chaikasoft.app.data.room.repo.RoomCartItemRepositoryInterface
 import com.chaikasoft.app.data.room.repo.RoomCartOperationRepository
@@ -32,95 +22,73 @@ import com.chaikasoft.app.data.room.repo.RoomStationRepository
 import com.chaikasoft.app.data.room.repo.RoomStationRepositoryInterface
 import com.chaikasoft.app.data.room.repo.RoomSyncMetaRepository
 import com.chaikasoft.app.data.room.repo.RoomSyncMetaRepositoryInterface
-import com.squareup.moshi.Moshi
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object RoomRepositoriesModule {
-    @Provides
+@Suppress("TooManyFunctions")
+interface RoomRepositoriesModule {
+    @Binds
     @Singleton
-    fun provideRoomCartOperationRepository(
-        cartOperationDao: CartOperationDao
-    ): RoomCartOperationRepositoryInterface = RoomCartOperationRepository(cartOperationDao)
+    fun bindRoomCartOperationRepository(
+        repository: RoomCartOperationRepository
+    ): RoomCartOperationRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomCartItemRepository(
-        cartItemDao: CartItemDao,
-        productInfoDao: ProductInfoDao
-    ): RoomCartItemRepositoryInterface = RoomCartItemRepository(cartItemDao, productInfoDao)
+    fun bindRoomCartItemRepository(
+        repository: RoomCartItemRepository
+    ): RoomCartItemRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomCartRepository(
-        db: AppDatabase,
-        cartItemDao: CartItemDao,
-        cartOperationDao: CartOperationDao
-    ): RoomCartRepositoryInterface = RoomCartRepository(db, cartItemDao, cartOperationDao)
+    fun bindRoomCartRepository(repository: RoomCartRepository): RoomCartRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomConductorRepository(
-        conductorDao: ConductorDao
-    ): RoomConductorRepositoryInterface = RoomConductorRepository(conductorDao)
+    fun bindRoomConductorRepository(
+        repository: RoomConductorRepository
+    ): RoomConductorRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomProductInfoRepository(
-        productInfoDao: ProductInfoDao
-    ): RoomProductInfoRepositoryInterface = RoomProductInfoRepository(productInfoDao)
+    fun bindRoomProductInfoRepository(
+        repository: RoomProductInfoRepository
+    ): RoomProductInfoRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomConductorTripShiftRepository(
-        conductorTripShiftDao: ConductorTripShiftDao
-    ): RoomConductorTripShiftRepositoryInterface =
-        RoomConductorTripShiftRepository(conductorTripShiftDao)
+    fun bindRoomConductorTripShiftRepository(
+        repository: RoomConductorTripShiftRepository
+    ): RoomConductorTripShiftRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomShiftReportRepository(
-        db: AppDatabase,
-        conductorTripShiftDao: ConductorTripShiftDao,
-        cartOperationDao: CartOperationDao,
-        cartItemDao: CartItemDao,
-        productInfoDao: ProductInfoDao,
-        moshi: Moshi
-    ): RoomShiftReportRepositoryInterface = RoomShiftReportRepository(
-        db = db,
-        conductorTripShiftDao = conductorTripShiftDao,
-        cartOperationDao = cartOperationDao,
-        cartItemDao = cartItemDao,
-        productInfoDao = productInfoDao,
-        moshi = moshi
-    )
+    fun bindRoomShiftReportRepository(
+        repository: RoomShiftReportRepository
+    ): RoomShiftReportRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomPackageItemRepository(
-        packageItemViewDao: PackageItemViewDao,
-        productInfoDao: ProductInfoDao
-    ): RoomPackageItemRepositoryInterface =
-        RoomPackageItemRepository(packageItemViewDao, productInfoDao)
+    fun bindRoomPackageItemRepository(
+        repository: RoomPackageItemRepository
+    ): RoomPackageItemRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomStationRepository(dao: StationDao): RoomStationRepositoryInterface =
-        RoomStationRepository(dao)
+    fun bindRoomStationRepository(repository: RoomStationRepository): RoomStationRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomSyncMetaRepository(dao: SyncMetaDao): RoomSyncMetaRepositoryInterface =
-        RoomSyncMetaRepository(dao)
+    fun bindRoomSyncMetaRepository(
+        repository: RoomSyncMetaRepository
+    ): RoomSyncMetaRepositoryInterface
 
-    @Provides
+    @Binds
     @Singleton
-    fun provideRoomReportRepository(
-        fastReportViewDao: FastReportViewDao
-    ): RoomReportRepositoryInterface = RoomReportRepository(fastReportViewDao)
+    fun bindRoomReportRepository(repository: RoomReportRepository): RoomReportRepositoryInterface
 }

--- a/app/src/main/java/com/chaikasoft/app/domain/mappers/HistoricalTripSnapshotMapper.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/mappers/HistoricalTripSnapshotMapper.kt
@@ -1,0 +1,155 @@
+package com.chaikasoft.app.domain.mappers
+
+import com.chaikasoft.app.domain.models.CartDomain
+import com.chaikasoft.app.domain.models.CartItemDomain
+import com.chaikasoft.app.domain.models.ConductorDomain
+import com.chaikasoft.app.domain.models.FastReportDomain
+import com.chaikasoft.app.domain.models.HistoricalOperationDomain
+import com.chaikasoft.app.domain.models.HistoricalTripSnapshot
+import com.chaikasoft.app.domain.models.OperationSummaryDomain
+import com.chaikasoft.app.domain.models.OperationTypeDomain
+import com.chaikasoft.app.domain.models.ProductInfoDomain
+import com.chaikasoft.app.domain.models.report.CartItemReport
+import com.chaikasoft.app.domain.models.report.CartReport
+import com.chaikasoft.app.domain.models.report.ShiftReportReport
+import kotlin.math.abs
+
+private const val UNKNOWN_PRODUCT_DESCRIPTION = ""
+private const val UNKNOWN_PRODUCT_IMAGE = ""
+
+/**
+ * Maps persisted shift report JSON model into read-only historical screen data.
+ *
+ * Product price and quantities are taken from the report snapshot. Product and conductor names are
+ * resolved from current local dictionaries; missing names stay empty and are localized in UI.
+ */
+suspend fun ShiftReportReport.toHistoricalTripSnapshot(
+    productsById: Map<Int, ProductInfoDomain>,
+    resolveConductor: suspend (String) -> ConductorDomain
+): HistoricalTripSnapshot {
+    val operations = carts.mapIndexed { index, cart ->
+        cart.toHistoricalOperation(
+            syntheticId = index + 1,
+            productsById = productsById,
+            resolveConductor = resolveConductor
+        )
+    }
+    val statistics = carts.toHistoricalStatistics(productsById)
+
+    return HistoricalTripSnapshot(
+        statistics = statistics,
+        cashRevenue = statistics.sumOf { it.revenue },
+        cashlessChecksCount = carts.count {
+            it.operationType == OperationTypeDomain.SOLD_CART.ordinal
+        },
+        operations = operations
+    )
+}
+
+private suspend fun CartReport.toHistoricalOperation(
+    syntheticId: Int,
+    productsById: Map<Int, ProductInfoDomain>,
+    resolveConductor: suspend (String) -> ConductorDomain
+): HistoricalOperationDomain {
+    val operationType = operationType.toHistoricalOperationType()
+    val cartDomain = CartDomain(
+        items = items.map { it.toDomainItem(productsById) }
+    )
+    val summary = OperationSummaryDomain(
+        id = syntheticId,
+        type = operationType,
+        timeIso = cartId.operationTime,
+        conductor = resolveConductor(cartId.employeeId),
+        productLineQuantity = items.map { it.productId }.distinct().size,
+        totalPrice = items.sumOf { abs(it.quantity) * it.price }
+    )
+
+    return HistoricalOperationDomain(
+        summary = summary,
+        cart = cartDomain
+    )
+}
+
+private fun List<CartReport>.toHistoricalStatistics(
+    productsById: Map<Int, ProductInfoDomain>
+): List<FastReportDomain> {
+    val accumulators = linkedMapOf<Int, HistoricalProductAccumulator>()
+    forEach { cart ->
+        val operationType = cart.operationType.toHistoricalOperationType()
+        cart.items.forEach { item ->
+            val accumulator = accumulators.getOrPut(item.productId) {
+                HistoricalProductAccumulator.from(
+                    item = item,
+                    product = productsById[item.productId]
+                )
+            }
+            accumulator.add(item, operationType)
+        }
+    }
+
+    return accumulators.values.map { it.toDomain() }
+}
+
+private fun Int.toHistoricalOperationType(): OperationTypeDomain =
+    OperationTypeDomain.entries.getOrNull(this)
+        ?: throw IllegalArgumentException("Unknown operation type $this")
+
+private fun CartItemReport.toDomainItem(productsById: Map<Int, ProductInfoDomain>): CartItemDomain {
+    val product = productsById[productId]
+    return CartItemDomain(
+        product = ProductInfoDomain(
+            id = productId,
+            name = product?.name.orEmpty(),
+            description = product?.description ?: UNKNOWN_PRODUCT_DESCRIPTION,
+            image = product?.image ?: UNKNOWN_PRODUCT_IMAGE,
+            price = price
+        ),
+        quantity = quantity
+    )
+}
+
+private data class HistoricalProductAccumulator(
+    val productId: Int,
+    val productName: String,
+    val productPrice: Int,
+    var addedQuantity: Int = 0,
+    var replenishedQuantity: Int = 0,
+    var soldCashQuantity: Int = 0,
+    var soldCartQuantity: Int = 0,
+    var revenue: Int = 0
+) {
+    fun add(item: CartItemReport, operationType: OperationTypeDomain) {
+        when (operationType) {
+            OperationTypeDomain.ADD -> addedQuantity += item.quantity
+            OperationTypeDomain.REPLENISH -> replenishedQuantity += item.quantity
+            OperationTypeDomain.SOLD_CASH -> {
+                val soldQuantity = -item.quantity
+                soldCashQuantity += soldQuantity
+                revenue += soldQuantity * item.price
+            }
+            OperationTypeDomain.SOLD_CART -> {
+                soldCartQuantity += -item.quantity
+            }
+        }
+    }
+
+    fun toDomain(): FastReportDomain = FastReportDomain(
+        productName = productName,
+        productPrice = productPrice,
+        addedQuantity = addedQuantity,
+        replenishedQuantity = replenishedQuantity,
+        soldCashQuantity = soldCashQuantity,
+        soldCartQuantity = soldCartQuantity,
+        revenue = revenue,
+        productId = productId
+    )
+
+    companion object {
+        fun from(item: CartItemReport, product: ProductInfoDomain?): HistoricalProductAccumulator =
+            HistoricalProductAccumulator(
+                productId = item.productId,
+                productName = product?.name.orEmpty(),
+                productPrice = item.price
+            )
+    }
+}

--- a/app/src/main/java/com/chaikasoft/app/domain/models/FastReportDomain.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/models/FastReportDomain.kt
@@ -11,6 +11,7 @@ package com.chaikasoft.app.domain.models
  * @param soldCashQuantity Количество проданных за наличные единиц.
  * @param soldCartQuantity Количество проданных по карте единиц.
  * @param revenue Выручка от продаж за наличные (цена * soldCashQuantity).
+ * @param productId Идентификатор товара, если отчётному экрану нужен fallback для имени.
  */
 data class FastReportDomain(
     val productName: String,
@@ -19,5 +20,6 @@ data class FastReportDomain(
     val replenishedQuantity: Int,
     val soldCashQuantity: Int,
     val soldCartQuantity: Int,
-    val revenue: Int
+    val revenue: Int,
+    val productId: Int? = null
 )

--- a/app/src/main/java/com/chaikasoft/app/domain/models/HistoricalTripSnapshot.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/models/HistoricalTripSnapshot.kt
@@ -1,0 +1,19 @@
+package com.chaikasoft.app.domain.models
+
+/**
+ * Read-only snapshot of a finished trip restored from the persisted shift report JSON.
+ *
+ * The snapshot is intentionally detached from live cart tables: historical screens must show
+ * exactly what was saved in `conductor_trip_shifts.report`.
+ */
+data class HistoricalTripSnapshot(
+    val statistics: List<FastReportDomain>,
+    val cashRevenue: Int,
+    val cashlessChecksCount: Int,
+    val operations: List<HistoricalOperationDomain>
+)
+
+/**
+ * Operation row restored from a historical report with its already resolved cart items.
+ */
+data class HistoricalOperationDomain(val summary: OperationSummaryDomain, val cart: CartDomain)

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/HistoricalTripUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/HistoricalTripUseCases.kt
@@ -1,0 +1,92 @@
+package com.chaikasoft.app.domain.usecases
+
+import com.chaikasoft.app.data.room.repo.RoomConductorRepositoryInterface
+import com.chaikasoft.app.data.room.repo.RoomProductInfoRepositoryInterface
+import com.chaikasoft.app.domain.mappers.toHistoricalTripSnapshot
+import com.chaikasoft.app.domain.models.ConductorDomain
+import com.chaikasoft.app.domain.models.HistoricalTripSnapshot
+import com.chaikasoft.app.domain.models.report.ShiftReportReport
+import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.Moshi
+import java.io.IOException
+import javax.inject.Inject
+
+private const val UNKNOWN_CONDUCTOR_GIVEN_NAME = ""
+private const val UNKNOWN_CONDUCTOR_IMAGE = ""
+
+class HistoricalTripSnapshotException(message: String, cause: Throwable? = null) :
+    IllegalStateException(message, cause)
+
+/**
+ * Restores a read-only historical trip snapshot from the saved shift report JSON.
+ *
+ * The use case never reads live cart operation tables. It parses the persisted report and resolves
+ * only display metadata, such as product and conductor names, from the current local database.
+ */
+class GetHistoricalTripSnapshotUseCase @Inject constructor(
+    private val getShiftReportJson: GetShiftReportJsonUseCase,
+    private val productRepository: RoomProductInfoRepositoryInterface,
+    private val conductorRepository: RoomConductorRepositoryInterface,
+    moshi: Moshi
+) {
+    private val adapter = moshi.adapter(ShiftReportReport::class.java)
+
+    suspend operator fun invoke(shiftUuid: String): HistoricalTripSnapshot {
+        val (status, reportJson) = getShiftReportJson(shiftUuid)
+        if (status != TripShiftStatusDomain.FINISHED && status != TripShiftStatusDomain.SENT) {
+            throw HistoricalTripSnapshotException(
+                "Historical report is unavailable for shift status $status"
+            )
+        }
+
+        val json = reportJson?.takeIf { it.isNotBlank() }
+            ?: throw HistoricalTripSnapshotException("Historical report is missing")
+        val report = parseReport(json)
+        val productsById = productRepository.getAllProductsOnce().associateBy { it.id }
+        val conductorsByEmployeeId = mutableMapOf<String, ConductorDomain>()
+
+        return report.toHistoricalTripSnapshot(
+            productsById = productsById,
+            resolveConductor = { employeeId ->
+                resolveConductor(
+                    employeeId = employeeId,
+                    conductorsByEmployeeId = conductorsByEmployeeId
+                )
+            }
+        )
+    }
+
+    private fun parseReport(json: String): ShiftReportReport {
+        val report = try {
+            adapter.fromJson(json)
+        } catch (error: IOException) {
+            throw HistoricalTripSnapshotException("Historical report is malformed", error)
+        } catch (error: JsonDataException) {
+            throw HistoricalTripSnapshotException("Historical report is malformed", error)
+        }
+
+        return report ?: throw HistoricalTripSnapshotException("Historical report is empty")
+    }
+
+    private suspend fun resolveConductor(
+        employeeId: String,
+        conductorsByEmployeeId: MutableMap<String, ConductorDomain>
+    ): ConductorDomain {
+        val cached = conductorsByEmployeeId[employeeId]
+        if (cached != null) return cached
+
+        val conductor = conductorRepository.getConductorByEmployeeID(employeeId)
+            ?: fallbackConductor(employeeId)
+        conductorsByEmployeeId[employeeId] = conductor
+        return conductor
+    }
+
+    private fun fallbackConductor(employeeId: String): ConductorDomain = ConductorDomain(
+        name = "",
+        familyName = "",
+        givenName = UNKNOWN_CONDUCTOR_GIVEN_NAME,
+        employeeID = employeeId,
+        image = UNKNOWN_CONDUCTOR_IMAGE
+    )
+}

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/ProductInfoUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/ProductInfoUseCases.kt
@@ -107,6 +107,10 @@ class RefreshProductsOnLaunchUseCase @Inject constructor(
         return System.currentTimeMillis() - lastSuccessfulSyncAt >= SyncDataset.PRODUCTS.ttlMs
     }
 
+    /**
+     * Converts any non-cancellation local persistence failure into the refresh boundary result.
+     */
+    @Suppress("TooGenericExceptionCaught")
     private suspend fun saveProductsIfChanged(
         remoteProducts: List<ProductInfoDomain>
     ): RefreshProductsResult = try {

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/StationUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/StationUseCases.kt
@@ -11,6 +11,7 @@ import com.chaikasoft.app.domain.common.RemoteResult
 import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.sealed.RefreshStationsResult
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -37,6 +38,10 @@ class RefreshStationsOnLaunchUseCase @Inject constructor(
         private const val ALL_STATIONS_LIMIT = 100_000
     }
 
+    /**
+     * Converts any non-cancellation local persistence failure into the refresh boundary result.
+     */
+    @Suppress("TooGenericExceptionCaught")
     suspend operator fun invoke(): RefreshStationsResult = withContext(ioDispatcher) {
         if (hasActiveShift()) return@withContext RefreshStationsResult.SkippedActiveShift
 
@@ -58,6 +63,8 @@ class RefreshStationsOnLaunchUseCase @Inject constructor(
                         timestampMillis = System.currentTimeMillis()
                     )
                     RefreshStationsResult.Success(stationCount = remote.data.size)
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
                 } catch (e: Exception) {
                     RefreshStationsResult.LocalFailure(e)
                 }

--- a/app/src/main/java/com/chaikasoft/app/ui/activities/MainActivity.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/activities/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.chaikasoft.app.ui.components.bottombar.BottomBar
+import com.chaikasoft.app.ui.components.bottombar.HistoricalTripBottomBar
 import com.chaikasoft.app.ui.components.bottombar.NavigationBlockedBottomSheet
 import com.chaikasoft.app.ui.components.topbar.MenuItem
 import com.chaikasoft.app.ui.components.topbar.TopBar
@@ -49,13 +50,17 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = navBackStackEntry?.destination?.route
+                val historicalShiftUuid =
+                    navBackStackEntry?.arguments?.getString(Routes.ARG_SHIFT_UUID)
                 val currentScreen = Screen.fromRoute(currentRoute)
                 var showBlockedNavigationSheet by remember { mutableStateOf(false) }
 
                 // Управление ориентацией экрана в зависимости от текущего маршрута
                 LaunchedEffect(currentRoute) {
-                    requestedOrientation = when (currentRoute) {
-                        Routes.STATISTICS -> ActivityInfo.SCREEN_ORIENTATION_SENSOR
+                    requestedOrientation = when {
+                        currentRoute == Routes.STATISTICS ||
+                            Routes.isHistoricalStatisticsRoute(currentRoute) ->
+                            ActivityInfo.SCREEN_ORIENTATION_SENSOR
                         else -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
                     }
                     if (currentRoute == Routes.TRIP_MAIN) {
@@ -76,6 +81,11 @@ class MainActivity : ComponentActivity() {
                             currentRoute = currentRoute,
                             navController = navController,
                             menuItems = if (currentScreen.showMenuIcon) menuItems else emptyList(),
+                            onBackClick = if (Routes.isHistoricalRoute(currentRoute)) {
+                                { navController.popBackStack(Routes.TRIP_MAIN, inclusive = false) }
+                            } else {
+                                null
+                            },
                             onMenuItemClick = { item ->
                                 when (item) {
                                     MenuItem.REFILL -> navController.navigate(
@@ -90,14 +100,22 @@ class MainActivity : ComponentActivity() {
                         )
                     },
                     bottomBar = {
-                        BottomBar(
-                            navController = navController,
-                            currentRoute = currentRoute,
-                            hasActiveShift = hasActiveShift,
-                            onBlockedNavigation = {
-                                showBlockedNavigationSheet = true
-                            }
-                        )
+                        if (Routes.isHistoricalRoute(currentRoute) && historicalShiftUuid != null) {
+                            HistoricalTripBottomBar(
+                                navController = navController,
+                                currentRoute = currentRoute,
+                                shiftUuid = historicalShiftUuid
+                            )
+                        } else {
+                            BottomBar(
+                                navController = navController,
+                                currentRoute = currentRoute,
+                                hasActiveShift = hasActiveShift,
+                                onBlockedNavigation = {
+                                    showBlockedNavigationSheet = true
+                                }
+                            )
+                        }
                     }
                 ) { paddingValues ->
                     Box(

--- a/app/src/main/java/com/chaikasoft/app/ui/components/bottombar/HistoricalTripBottomBar.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/bottombar/HistoricalTripBottomBar.kt
@@ -1,0 +1,82 @@
+package com.chaikasoft.app.ui.components.bottombar
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.chaikasoft.app.R
+import com.chaikasoft.app.ui.navigation.Routes
+import com.chaikasoft.app.ui.theme.BarDimens
+
+@Composable
+fun HistoricalTripBottomBar(
+    navController: NavController,
+    currentRoute: String?,
+    shiftUuid: String
+) {
+    fun navigateToHistoricalTab(route: String) {
+        val alreadySelected =
+            (
+                Routes.isHistoricalStatisticsRoute(currentRoute) &&
+                    Routes.isHistoricalStatisticsRoute(route)
+                ) ||
+                (
+                    Routes.isHistoricalOperationsRoute(currentRoute) &&
+                        Routes.isHistoricalOperationsRoute(route)
+                    )
+        if (alreadySelected) {
+            return
+        }
+
+        navController.navigate(route) {
+            popUpTo(Routes.HISTORY_GRAPH) {
+                inclusive = false
+                saveState = true
+            }
+            launchSingleTop = true
+            restoreState = true
+        }
+    }
+
+    BottomBarBackground(
+        modifier = Modifier.shadow(
+            elevation = 10.dp,
+            shape = RoundedCornerShape(
+                topStart = 20.dp,
+                topEnd = 20.dp
+            ),
+            clip = true
+        ),
+        height = BarDimens.BarHeight
+    )
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BarDimens.BarHeight),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BottomBarIcon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_statistics),
+            selected = Routes.isHistoricalStatisticsRoute(currentRoute),
+            tag = "historicalBottomBarStatistics",
+            onClick = { navigateToHistoricalTab(Routes.historyStatistics(shiftUuid)) }
+        )
+        BottomBarIcon(
+            imageVector = ImageVector.vectorResource(id = R.drawable.ic_time),
+            selected = Routes.isHistoricalOperationsRoute(currentRoute),
+            tag = "historicalBottomBarOperation",
+            onClick = { navigateToHistoricalTab(Routes.historyOperations(shiftUuid)) }
+        )
+    }
+}

--- a/app/src/main/java/com/chaikasoft/app/ui/components/operation/OperationCard.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/operation/OperationCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.chaikasoft.app.R
+import com.chaikasoft.app.domain.models.CartDomain
 import com.chaikasoft.app.domain.models.CartItemDomain
 import com.chaikasoft.app.domain.models.OperationSummaryDomain
 import com.chaikasoft.app.domain.models.OperationTypeDomain
@@ -51,6 +52,11 @@ fun OperationCard(summary: OperationSummaryDomain, viewModel: OperationViewModel
     val itemsFlow = remember(summary.id) { viewModel.getItems(summary.id) }
     val cart by itemsFlow.collectAsStateWithLifecycle(initialValue = null)
 
+    OperationCard(summary = summary, cart = cart)
+}
+
+@Composable
+fun OperationCard(summary: OperationSummaryDomain, cart: CartDomain?) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -131,8 +137,12 @@ fun OperationCard(summary: OperationSummaryDomain, viewModel: OperationViewModel
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
+                val conductorName = listOf(
+                    summary.conductor.name,
+                    summary.conductor.familyName
+                ).filter { it.isNotBlank() }.joinToString(" ")
                 Text(
-                    text = "${summary.conductor.name} ${summary.conductor.familyName}",
+                    text = conductorName,
                     fontSize = OperationDimens.FooterFontSize,
                     color = MaterialTheme.colorScheme.secondary
                 )

--- a/app/src/main/java/com/chaikasoft/app/ui/components/topbar/TopBar.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/topbar/TopBar.kt
@@ -26,7 +26,8 @@ fun TopBar(
     navController: NavController,
     currentRoute: String?,
     menuItems: List<MenuItem> = emptyList(),
-    onMenuItemClick: (MenuItem) -> Unit = {}
+    onMenuItemClick: (MenuItem) -> Unit = {},
+    onBackClick: (() -> Unit)? = null
 ) {
     if (currentRoute != null && currentRoute in Routes.routesWithoutTopBar) return
 
@@ -37,7 +38,7 @@ fun TopBar(
         navigationIcon = {
             if (currentScreen?.showBackButton == true) {
                 CircleBackButton(
-                    onClick = { navController.navigateUp() },
+                    onClick = { onBackClick?.invoke() ?: navController.navigateUp() },
                     modifier = Modifier.padding(start = 8.dp, end = 8.dp)
                 )
             }

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordCard.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordCard.kt
@@ -4,11 +4,22 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import com.chaikasoft.app.ui.theme.TripDimens
@@ -30,6 +41,7 @@ fun HistoryRecordCard(
 
     Box(
         modifier = modifier
+            .testTag("historyRecordCard_${tripRecord.uuid}")
             .height(TripDimens.RecordCardHeight)
             .width(TripDimens.CardWidth)
             .background(
@@ -38,7 +50,7 @@ fun HistoryRecordCard(
             )
             .clip(MaterialTheme.shapes.medium)
             .clickable {
-                if (isError) onRetrySend() else onNavigate()
+                onNavigate()
             }
     ) {
         HistoryRecordContent(
@@ -48,5 +60,22 @@ fun HistoryRecordCard(
             tripRecord = tripRecord,
             isError = isError
         )
+
+        if (isError) {
+            IconButton(
+                onClick = onRetrySend,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(2.dp)
+                    .size(32.dp)
+                    .testTag("historyRetrySend_${tripRecord.uuid}")
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.retry_action),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/navigation/NavGraph.kt
@@ -12,10 +12,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import androidx.navigation.navArgument
 import com.chaikasoft.app.ui.screens.auth.LoginScreen
+import com.chaikasoft.app.ui.screens.operation.HistoricalOperationScreen
 import com.chaikasoft.app.ui.screens.operation.OperationScreen
 import com.chaikasoft.app.ui.screens.product.ProductCartView
 import com.chaikasoft.app.ui.screens.product.ProductEntryView
@@ -31,6 +34,7 @@ import com.chaikasoft.app.ui.screens.profile.FeedbackView
 import com.chaikasoft.app.ui.screens.profile.MainProfileView
 import com.chaikasoft.app.ui.screens.profile.PersonalDataView
 import com.chaikasoft.app.ui.screens.profile.SettingsView
+import com.chaikasoft.app.ui.screens.statistics.HistoricalStatisticsScreen
 import com.chaikasoft.app.ui.screens.statistics.StatisticsScreen
 import com.chaikasoft.app.ui.screens.trip.AutonomousTripScreen
 import com.chaikasoft.app.ui.screens.trip.FindByNumberView
@@ -43,6 +47,7 @@ import com.chaikasoft.app.ui.viewmodels.AuthViewModel
 import com.chaikasoft.app.ui.viewmodels.AutonomousViewModel
 import com.chaikasoft.app.ui.viewmodels.ConductorViewModel
 import com.chaikasoft.app.ui.viewmodels.FillViewModel
+import com.chaikasoft.app.ui.viewmodels.HistoricalTripViewModel
 import com.chaikasoft.app.ui.viewmodels.OperationViewModel
 import com.chaikasoft.app.ui.viewmodels.PackageViewModel
 import com.chaikasoft.app.ui.viewmodels.PostAuthGateViewModel
@@ -215,6 +220,42 @@ fun NavGraph(
                     viewModel = tripViewModel,
                     navController = navController
                 )
+            }
+
+            navigation(
+                startDestination = Routes.HISTORY_STATISTICS,
+                route = Routes.HISTORY_GRAPH,
+                arguments = listOf(
+                    navArgument(Routes.ARG_SHIFT_UUID) { type = NavType.StringType }
+                )
+            ) {
+                composable(
+                    route = Routes.HISTORY_STATISTICS,
+                    arguments = listOf(
+                        navArgument(Routes.ARG_SHIFT_UUID) { type = NavType.StringType }
+                    )
+                ) { backStackEntry ->
+                    val parentEntry = remember(backStackEntry) {
+                        navController.getBackStackEntry(Routes.HISTORY_GRAPH)
+                    }
+                    val historicalTripViewModel =
+                        hiltViewModel<HistoricalTripViewModel>(parentEntry)
+                    HistoricalStatisticsScreen(viewModel = historicalTripViewModel)
+                }
+
+                composable(
+                    route = Routes.HISTORY_OPERATIONS,
+                    arguments = listOf(
+                        navArgument(Routes.ARG_SHIFT_UUID) { type = NavType.StringType }
+                    )
+                ) { backStackEntry ->
+                    val parentEntry = remember(backStackEntry) {
+                        navController.getBackStackEntry(Routes.HISTORY_GRAPH)
+                    }
+                    val historicalTripViewModel =
+                        hiltViewModel<HistoricalTripViewModel>(parentEntry)
+                    HistoricalOperationScreen(viewModel = historicalTripViewModel)
+                }
             }
         }
 

--- a/app/src/main/java/com/chaikasoft/app/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/navigation/Routes.kt
@@ -14,6 +14,10 @@ object Routes {
     const val TRIP_BY_STATION = "trip/graph/by_station"
     const val TRIP_SELECT_CARRIAGE = "trip/graph/select_carriage"
     const val TRIP_GRAPH = "trip/graph"
+    const val ARG_SHIFT_UUID = "shiftUuid"
+    const val HISTORY_GRAPH = "trip/graph/history/{$ARG_SHIFT_UUID}"
+    const val HISTORY_STATISTICS = "trip/graph/history/{$ARG_SHIFT_UUID}/statistics"
+    const val HISTORY_OPERATIONS = "trip/graph/history/{$ARG_SHIFT_UUID}/operations"
     const val PRODUCT = "product"
     const val PRODUCT_GRAPH = "product/graph"
     const val PRODUCT_GATE = "product/graph/gate"
@@ -44,7 +48,8 @@ object Routes {
         TEMPLATE_SEARCH, TEMPLATE_DETAIL, TEMPLATE_EDIT,
         TEMPLATE_CONFIRM, PRODUCT_REPLENISH, TRIP_AUTONOMOUS,
         TRIP_AUTONOMOUS, TRIP_BY_STATION, TRIP_BY_NUMBER,
-        TRIP_GATE, TRIP_SELECT_CARRIAGE
+        TRIP_GATE, TRIP_SELECT_CARRIAGE,
+        HISTORY_GRAPH, HISTORY_STATISTICS, HISTORY_OPERATIONS
     )
 
     val routesWithoutTopBar = setOf(
@@ -62,7 +67,10 @@ object Routes {
             TRIP_BY_NUMBER,
             TRIP_BY_STATION,
             TRIP_SELECT_CARRIAGE,
-            TRIP_AUTONOMOUS
+            TRIP_AUTONOMOUS,
+            HISTORY_GRAPH,
+            HISTORY_STATISTICS,
+            HISTORY_OPERATIONS
         ),
         PRODUCT to listOf(
             PRODUCT_GATE,
@@ -92,4 +100,23 @@ object Routes {
             TEMPLATE_CONFIRM
         )
     )
+
+    fun historyGraph(shiftUuid: String): String = "trip/graph/history/$shiftUuid"
+
+    fun historyStatistics(shiftUuid: String): String = "trip/graph/history/$shiftUuid/statistics"
+
+    fun historyOperations(shiftUuid: String): String = "trip/graph/history/$shiftUuid/operations"
+
+    fun isHistoricalGraphRoute(route: String?): Boolean =
+        route == HISTORY_GRAPH || route?.matches(Regex("trip/graph/history/[^/]+")) == true
+
+    fun isHistoricalStatisticsRoute(route: String?): Boolean = route == HISTORY_STATISTICS ||
+        route?.matches(Regex("trip/graph/history/[^/]+/statistics")) == true
+
+    fun isHistoricalOperationsRoute(route: String?): Boolean = route == HISTORY_OPERATIONS ||
+        route?.matches(Regex("trip/graph/history/[^/]+/operations")) == true
+
+    fun isHistoricalRoute(route: String?): Boolean = isHistoricalGraphRoute(route) ||
+        isHistoricalStatisticsRoute(route) ||
+        isHistoricalOperationsRoute(route)
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/navigation/Screen.kt
@@ -34,8 +34,10 @@ sealed class Screen(
     object Replenish : Screen(Routes.PRODUCT_REPLENISH, R.string.product_replenish)
 
     object Statistics : Screen(Routes.STATISTICS, R.string.statistics_title, showBackButton = false)
+    object HistoricalStatistics : Screen(Routes.HISTORY_STATISTICS, R.string.statistics_title)
 
     object Operation : Screen(Routes.OPERATION, R.string.operations_title, showBackButton = false)
+    object HistoricalOperation : Screen(Routes.HISTORY_OPERATIONS, R.string.operations_title)
 
     object Profile : Screen(Routes.PROFILE, R.string.profile_title, showBackButton = false)
     object ProfilePersonalData : Screen(
@@ -56,30 +58,35 @@ sealed class Screen(
     )
 
     companion object {
-        fun fromRoute(route: String?): Screen = when (route) {
-            Routes.TRIP -> Trip
-            Routes.TRIP_MAIN -> MainTrip
-            Routes.TRIP_AUTONOMOUS -> AutonomousTrip
-            Routes.TRIP_BY_NUMBER -> FindTripByNumber
-            Routes.TRIP_SELECT_CARRIAGE -> SelectCarriage
-            Routes.PRODUCT -> Product
-            Routes.PRODUCT_ENTRY -> ProductEntry
-            Routes.PRODUCT_CART -> Cart
-            Routes.PRODUCT_PACKAGE -> Package
-            Routes.PRODUCT_REPLENISH -> Replenish
-            Routes.OPERATION -> Operation
-            Routes.PROFILE -> Profile
-            Routes.PROFILE_PERSONAL_DATA -> ProfilePersonalData
-            Routes.PROFILE_SETTINGS -> ProfileSettings
-            Routes.PROFILE_FAQS -> ProfileFaqs
-            Routes.PROFILE_FEEDBACK -> ProfileFeedback
-            Routes.PROFILE_ABOUT -> ProfileAbout
-            Routes.TEMPLATE_SEARCH -> TemplateSearch
-            Routes.TEMPLATE_DETAIL -> TemplateDetail
-            Routes.TEMPLATE_EDIT -> TemplateEdit
-            Routes.TEMPLATE_CONFIRM -> TemplateConfirm
-            Routes.STATISTICS -> Statistics
-            else -> Trip
+        private val screensByRoute = mapOf(
+            Routes.TRIP to Trip,
+            Routes.TRIP_MAIN to MainTrip,
+            Routes.TRIP_AUTONOMOUS to AutonomousTrip,
+            Routes.TRIP_BY_NUMBER to FindTripByNumber,
+            Routes.TRIP_SELECT_CARRIAGE to SelectCarriage,
+            Routes.PRODUCT to Product,
+            Routes.PRODUCT_ENTRY to ProductEntry,
+            Routes.PRODUCT_CART to Cart,
+            Routes.PRODUCT_PACKAGE to Package,
+            Routes.PRODUCT_REPLENISH to Replenish,
+            Routes.OPERATION to Operation,
+            Routes.PROFILE to Profile,
+            Routes.PROFILE_PERSONAL_DATA to ProfilePersonalData,
+            Routes.PROFILE_SETTINGS to ProfileSettings,
+            Routes.PROFILE_FAQS to ProfileFaqs,
+            Routes.PROFILE_FEEDBACK to ProfileFeedback,
+            Routes.PROFILE_ABOUT to ProfileAbout,
+            Routes.TEMPLATE_SEARCH to TemplateSearch,
+            Routes.TEMPLATE_DETAIL to TemplateDetail,
+            Routes.TEMPLATE_EDIT to TemplateEdit,
+            Routes.TEMPLATE_CONFIRM to TemplateConfirm,
+            Routes.STATISTICS to Statistics
+        )
+
+        fun fromRoute(route: String?): Screen = when {
+            Routes.isHistoricalStatisticsRoute(route) -> HistoricalStatistics
+            Routes.isHistoricalOperationsRoute(route) -> HistoricalOperation
+            else -> route?.let(screensByRoute::get) ?: Trip
         }
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/operation/HistoricalOperationScreen.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/operation/HistoricalOperationScreen.kt
@@ -1,0 +1,98 @@
+package com.chaikasoft.app.ui.screens.operation
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chaikasoft.app.R
+import com.chaikasoft.app.domain.models.HistoricalOperationDomain
+import com.chaikasoft.app.ui.components.operation.OperationCard
+import com.chaikasoft.app.ui.screens.util.HistoricalTripErrorContent
+import com.chaikasoft.app.ui.screens.util.LoadingScreen
+import com.chaikasoft.app.ui.state.HistoricalTripUiState
+import com.chaikasoft.app.ui.viewmodels.HistoricalTripViewModel
+
+@Composable
+fun HistoricalOperationScreen(viewModel: HistoricalTripViewModel) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val currentState = state) {
+        HistoricalTripUiState.Loading -> LoadingScreen()
+        is HistoricalTripUiState.Error -> HistoricalTripErrorContent(
+            message = stringResource(currentState.messageRes)
+        )
+        is HistoricalTripUiState.Content -> HistoricalOperationContent(
+            operations = currentState.snapshot.operations.withLocalizedFallbackNames()
+        )
+    }
+}
+
+@Composable
+fun HistoricalOperationContent(
+    operations: List<HistoricalOperationDomain>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag("historicalOperationScreen")
+    ) {
+        items(
+            items = operations,
+            key = { it.summary.id }
+        ) { operation ->
+            OperationCard(summary = operation.summary, cart = operation.cart)
+        }
+    }
+}
+
+@Composable
+private fun List<HistoricalOperationDomain>.withLocalizedFallbackNames():
+    List<HistoricalOperationDomain> =
+    buildList {
+        this@withLocalizedFallbackNames.forEach { operation ->
+            val conductor = operation.summary.conductor
+            val conductorWithName = if (conductor.name.isBlank() &&
+                conductor.familyName.isBlank()
+            ) {
+                conductor.copy(
+                    name = stringResource(
+                        R.string.historical_unknown_conductor_name,
+                        conductor.employeeID
+                    )
+                )
+            } else {
+                conductor
+            }
+            val itemsWithNames = buildList {
+                operation.cart.items.forEach { item ->
+                    val product = item.product
+                    add(
+                        if (product.name.isBlank()) {
+                            item.copy(
+                                product = product.copy(
+                                    name = stringResource(
+                                        R.string.historical_unknown_product_name,
+                                        product.id
+                                    )
+                                )
+                            )
+                        } else {
+                            item
+                        }
+                    )
+                }
+            }
+            add(
+                operation.copy(
+                    summary = operation.summary.copy(conductor = conductorWithName),
+                    cart = operation.cart.copy(items = itemsWithNames)
+                )
+            )
+        }
+    }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/statistics/HistoricalStatisticsScreen.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/statistics/HistoricalStatisticsScreen.kt
@@ -1,0 +1,48 @@
+package com.chaikasoft.app.ui.screens.statistics
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chaikasoft.app.R
+import com.chaikasoft.app.domain.models.FastReportDomain
+import com.chaikasoft.app.ui.screens.util.HistoricalTripErrorContent
+import com.chaikasoft.app.ui.screens.util.LoadingScreen
+import com.chaikasoft.app.ui.state.HistoricalTripUiState
+import com.chaikasoft.app.ui.viewmodels.HistoricalTripViewModel
+
+@Composable
+fun HistoricalStatisticsScreen(viewModel: HistoricalTripViewModel) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val currentState = state) {
+        HistoricalTripUiState.Loading -> LoadingScreen()
+        is HistoricalTripUiState.Error -> HistoricalTripErrorContent(
+            message = stringResource(currentState.messageRes)
+        )
+        is HistoricalTripUiState.Content -> StatisticsContent(
+            reports = currentState.snapshot.statistics.withLocalizedFallbackNames(),
+            cashRevenue = currentState.snapshot.cashRevenue,
+            cashlessChecks = currentState.snapshot.cashlessChecksCount
+        )
+    }
+}
+
+@Composable
+private fun List<FastReportDomain>.withLocalizedFallbackNames(): List<FastReportDomain> =
+    buildList {
+        this@withLocalizedFallbackNames.forEach { report ->
+            val fallbackProductId = report.productId
+            val reportWithName = if (report.productName.isBlank() && fallbackProductId != null) {
+                report.copy(
+                    productName = stringResource(
+                        R.string.historical_unknown_product_name,
+                        fallbackProductId
+                    )
+                )
+            } else {
+                report
+            }
+            add(reportWithName)
+        }
+    }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/statistics/StatisticsScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.BottomSheetScaffold
@@ -39,6 +39,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -91,8 +92,26 @@ fun StatisticsScreen(
 ) {
     val reports by viewModel.reports.collectAsStateWithLifecycle()
     val cashRevenue by viewModel.cashRevenue.collectAsStateWithLifecycle()
-    val cashChecks by viewModel.cashChecksCount.collectAsStateWithLifecycle()
+    val cashlessChecks by viewModel.cashlessChecksCount.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) { viewModel.refreshCashlessChecks() }
+
+    StatisticsContent(
+        modifier = modifier,
+        reports = reports,
+        cashRevenue = cashRevenue,
+        cashlessChecks = cashlessChecks
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun StatisticsContent(
+    modifier: Modifier = Modifier,
+    reports: List<FastReportDomain>,
+    cashRevenue: Int,
+    cashlessChecks: Int
+) {
     val columnWidths = rememberColumnWidths()
     val configuration = LocalConfiguration.current
     val isLandscape =
@@ -100,8 +119,6 @@ fun StatisticsScreen(
 
     val sharedHScroll = rememberScrollState()
     val scaffoldState = rememberBottomSheetScaffoldState()
-
-    LaunchedEffect(Unit) { viewModel.refreshCartChecks() }
 
     BottomSheetScaffold(
         scaffoldState = scaffoldState,
@@ -121,7 +138,7 @@ fun StatisticsScreen(
 
             CashSummarySheet(
                 cashRevenue = cashRevenue,
-                checks = cashChecks,
+                cashlessChecks = cashlessChecks,
                 showChecks = show,
                 showLabels = show,
                 bottomPadding = if (show) 56.dp else 0.dp
@@ -147,10 +164,10 @@ fun StatisticsScreen(
                     )
                 }
             }
-            items(
+            itemsIndexed(
                 items = reports,
-                key = { it.productName }
-            ) { report ->
+                key = { index, report -> "${report.productName}_${report.productPrice}_$index" }
+            ) { _, report ->
                 TableRow(
                     report = report,
                     scrollState = sharedHScroll,
@@ -165,7 +182,7 @@ fun StatisticsScreen(
 @Composable
 private fun CashSummarySheet(
     cashRevenue: Int,
-    checks: Int,
+    cashlessChecks: Int,
     showChecks: Boolean,
     showLabels: Boolean,
     bottomPadding: Dp
@@ -213,8 +230,11 @@ private fun CashSummarySheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Чеков (нал.)", style = MaterialTheme.typography.bodyMedium)
-                Text(checks.toString(), style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    stringResource(R.string.cashless_checks),
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(cashlessChecks.toString(), style = MaterialTheme.typography.bodyMedium)
             }
         }
     }
@@ -244,14 +264,14 @@ private fun TableHeader(scrollState: ScrollState, widths: ColumnWidths, isLandsc
             HeaderIconCell(R.drawable.ic_rub, widths.price)
             HeaderIconCell(R.drawable.ic_add, widths.qty)
             HeaderIconCell(R.drawable.ic_replenish, widths.qty)
-            HeaderIconCell(R.drawable.ic_card, widths.qty)
             HeaderIconCell(R.drawable.ic_cash, widths.qty)
+            HeaderIconCell(R.drawable.ic_card, widths.qty)
             Box(
                 modifier = Modifier.width(widths.revenue),
                 contentAlignment = Alignment.CenterEnd
             ) {
                 Text(
-                    text = "Итог",
+                    text = stringResource(R.string.cash_revenue_total),
                     color = Color.Black,
                     maxLines = 1,
                     style = TableText,

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/trip/MainTripView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/trip/MainTripView.kt
@@ -63,7 +63,7 @@ fun MainTripView(viewModel: TripViewModel, navController: NavController) {
                         viewModel.requestRetrySend(shiftRecord.trip.uuid)
                     },
                     onNavigate = {
-                        // No-op for now.
+                        navController.navigate(Routes.historyStatistics(shiftRecord.trip.uuid))
                     }
                 )
             }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/util/HistoricalTripErrorContent.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/util/HistoricalTripErrorContent.kt
@@ -1,0 +1,32 @@
+package com.chaikasoft.app.ui.screens.util
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun HistoricalTripErrorContent(message: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("historicalTripError"),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/chaikasoft/app/ui/state/HistoricalTripUiState.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/state/HistoricalTripUiState.kt
@@ -1,0 +1,12 @@
+package com.chaikasoft.app.ui.state
+
+import androidx.annotation.StringRes
+import com.chaikasoft.app.domain.models.HistoricalTripSnapshot
+
+sealed interface HistoricalTripUiState {
+    data object Loading : HistoricalTripUiState
+
+    data class Content(val snapshot: HistoricalTripSnapshot) : HistoricalTripUiState
+
+    data class Error(@StringRes val messageRes: Int) : HistoricalTripUiState
+}

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/HistoricalTripViewModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/HistoricalTripViewModel.kt
@@ -1,0 +1,44 @@
+package com.chaikasoft.app.ui.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.chaikasoft.app.R
+import com.chaikasoft.app.domain.usecases.GetHistoricalTripSnapshotUseCase
+import com.chaikasoft.app.ui.navigation.Routes
+import com.chaikasoft.app.ui.state.HistoricalTripUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class HistoricalTripViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getHistoricalTripSnapshot: GetHistoricalTripSnapshotUseCase
+) : ViewModel() {
+    private val shiftUuid: String = checkNotNull(savedStateHandle[Routes.ARG_SHIFT_UUID])
+
+    private val _uiState = MutableStateFlow<HistoricalTripUiState>(HistoricalTripUiState.Loading)
+    val uiState: StateFlow<HistoricalTripUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.value = HistoricalTripUiState.Loading
+            _uiState.value = try {
+                HistoricalTripUiState.Content(getHistoricalTripSnapshot(shiftUuid))
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Exception) {
+                HistoricalTripUiState.Error(R.string.trip_finish_missing_report)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/StatisticsViewModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/StatisticsViewModel.kt
@@ -32,13 +32,13 @@ class StatisticsViewModel @Inject constructor(
             .map { list -> list.sumOf { it.productPrice * it.soldCashQuantity } }
             .stateIn(viewModelScope, SharingStarted.Lazily, 0)
 
-    private val _cashChecksCount = MutableStateFlow(0)
-    val cashChecksCount: StateFlow<Int> = _cashChecksCount.asStateFlow()
+    private val _cashlessChecksCount = MutableStateFlow(0)
+    val cashlessChecksCount: StateFlow<Int> = _cashlessChecksCount.asStateFlow()
 
     /** Вызывать при старте экрана и, при желании, при расширении шторки */
-    fun refreshCartChecks() {
+    fun refreshCashlessChecks() {
         viewModelScope.launch {
-            _cashChecksCount.value = getOperationCountByType(OperationTypeDomain.SOLD_CART)
+            _cashlessChecksCount.value = getOperationCountByType(OperationTypeDomain.SOLD_CART)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,7 +221,7 @@
     <string name="template_check_contents">Вы уверены?\nПожалуйста, проверьте содержимое пакета</string>
     <string name="template_cancel">ОТМЕНА</string>
     <string name="error_no_conductor">Ошибка: проводник не выбран</string>
-    
+
     <string name="empty_product_list">No products available</string>
     <string name="error_loading_products">Failed to load products</string>
     <string name="retry">ПОВТОРИТЬ</string>
@@ -255,6 +255,10 @@
     <!-- Units & formats -->
     <string name="op_quantity_suffix">шт</string>
     <string name="statistics_title">Статистика</string>
+    <string name="cashless_checks">Чеков (безнал.)</string>
+    <string name="cash_revenue_total">Итог</string>
+    <string name="historical_unknown_product_name">Товар #%1$d</string>
+    <string name="historical_unknown_conductor_name">Проводник #%1$s</string>
 
     <!-- Finish trip an send report -->
     <string name="trip_finish_title">Завершение поездки</string>

--- a/app/src/test/java/com/chaikasoft/app/domain/usecases/historicalTripUseCases/GetHistoricalTripSnapshotUseCaseTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/domain/usecases/historicalTripUseCases/GetHistoricalTripSnapshotUseCaseTest.kt
@@ -1,0 +1,211 @@
+package com.chaikasoft.app.domain.usecases.historicalTripUseCases
+
+import com.chaikasoft.app.data.room.repo.RoomConductorRepositoryInterface
+import com.chaikasoft.app.data.room.repo.RoomProductInfoRepositoryInterface
+import com.chaikasoft.app.domain.models.OperationTypeDomain
+import com.chaikasoft.app.domain.models.report.CartIdReport
+import com.chaikasoft.app.domain.models.report.CartItemReport
+import com.chaikasoft.app.domain.models.report.CartReport
+import com.chaikasoft.app.domain.models.report.ShiftReportReport
+import com.chaikasoft.app.domain.models.report.TripIdReport
+import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.usecases.GetHistoricalTripSnapshotUseCase
+import com.chaikasoft.app.domain.usecases.GetShiftReportJsonUseCase
+import com.chaikasoft.app.domain.usecases.HistoricalTripSnapshotException
+import com.chaikasoft.app.ui.conductor
+import com.chaikasoft.app.ui.productInfo
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+
+class GetHistoricalTripSnapshotUseCaseTest : FunSpec({
+
+    lateinit var getShiftReportJson: GetShiftReportJsonUseCase
+    lateinit var productRepository: RoomProductInfoRepositoryInterface
+    lateinit var conductorRepository: RoomConductorRepositoryInterface
+    lateinit var useCase: GetHistoricalTripSnapshotUseCase
+
+    val shiftUuid = "shift-uuid"
+    val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    beforeTest {
+        getShiftReportJson = mockk()
+        productRepository = mockk()
+        conductorRepository = mockk()
+        useCase = GetHistoricalTripSnapshotUseCase(
+            getShiftReportJson = getShiftReportJson,
+            productRepository = productRepository,
+            conductorRepository = conductorRepository,
+            moshi = moshi
+        )
+    }
+
+    test("restores statistics and operations from persisted report json") {
+        runTest {
+            val json = reportJson(
+                carts = listOf(
+                    cart(OperationTypeDomain.ADD, "123", "2026-01-01T10:00:00Z", item(1, 5, 1000)),
+                    cart(
+                        OperationTypeDomain.REPLENISH,
+                        "123",
+                        "2026-01-01T10:05:00Z",
+                        item(1, 3, 1000)
+                    ),
+                    cart(
+                        OperationTypeDomain.SOLD_CASH,
+                        "123",
+                        "2026-01-01T10:10:00Z",
+                        item(1, -2, 1000),
+                        item(2, -1, 500)
+                    ),
+                    cart(
+                        OperationTypeDomain.SOLD_CART,
+                        "999",
+                        "2026-01-01T10:15:00Z",
+                        item(2, -2, 500)
+                    )
+                ),
+                moshi = moshi
+            )
+            coEvery { getShiftReportJson(shiftUuid) } returns (TripShiftStatusDomain.SENT to json)
+            coEvery { productRepository.getAllProductsOnce() } returns listOf(
+                productInfo(id = 1, name = "Tea", price = 900)
+            )
+            coEvery { conductorRepository.getConductorByEmployeeID("123") } returns
+                conductor().copy(employeeID = "123")
+            coEvery { conductorRepository.getConductorByEmployeeID("999") } returns null
+
+            val snapshot = useCase(shiftUuid)
+
+            snapshot.statistics shouldHaveSize 2
+            snapshot.statistics[0].productName shouldBe "Tea"
+            snapshot.statistics[0].productPrice shouldBe 1000
+            snapshot.statistics[0].addedQuantity shouldBe 5
+            snapshot.statistics[0].replenishedQuantity shouldBe 3
+            snapshot.statistics[0].soldCashQuantity shouldBe 2
+            snapshot.statistics[0].soldCartQuantity shouldBe 0
+            snapshot.statistics[0].revenue shouldBe 2000
+
+            snapshot.statistics[1].productId shouldBe 2
+            snapshot.statistics[1].productName shouldBe ""
+            snapshot.statistics[1].productPrice shouldBe 500
+            snapshot.statistics[1].soldCashQuantity shouldBe 1
+            snapshot.statistics[1].soldCartQuantity shouldBe 2
+            snapshot.statistics[1].revenue shouldBe 500
+
+            snapshot.cashRevenue shouldBe 2500
+            snapshot.cashlessChecksCount shouldBe 1
+
+            snapshot.operations shouldHaveSize 4
+            snapshot.operations[0].summary.id shouldBe 1
+            snapshot.operations[0].summary.type shouldBe OperationTypeDomain.ADD
+            snapshot.operations[0].summary.timeIso shouldBe "2026-01-01T10:00:00Z"
+            snapshot.operations[0].cart.items.single().product.name shouldBe "Tea"
+            snapshot.operations[0].cart.items.single().product.price shouldBe 1000
+            snapshot.operations[2].summary.totalPrice shouldBe 2500
+            snapshot.operations[3].summary.conductor.name shouldBe ""
+            snapshot.operations[3].summary.conductor.familyName shouldBe ""
+        }
+    }
+
+    test("throws when report is missing") {
+        runTest {
+            coEvery { getShiftReportJson(shiftUuid) } returns (TripShiftStatusDomain.FINISHED to null)
+
+            shouldThrow<HistoricalTripSnapshotException> {
+                useCase(shiftUuid)
+            }
+        }
+    }
+
+    test("throws when report json is malformed") {
+        runTest {
+            coEvery { getShiftReportJson(shiftUuid) } returns
+                (TripShiftStatusDomain.FINISHED to """{"trip_id":""")
+
+            val error = shouldThrow<HistoricalTripSnapshotException> {
+                useCase(shiftUuid)
+            }
+
+            error.message shouldBe "Historical report is malformed"
+        }
+    }
+
+    test("throws empty report error when report json contains null") {
+        runTest {
+            coEvery { getShiftReportJson(shiftUuid) } returns
+                (TripShiftStatusDomain.FINISHED to "null")
+
+            val error = shouldThrow<HistoricalTripSnapshotException> {
+                useCase(shiftUuid)
+            }
+
+            error.message shouldBe "Historical report is empty"
+        }
+    }
+
+    test("throws malformed report error when json structure is incompatible") {
+        runTest {
+            coEvery { getShiftReportJson(shiftUuid) } returns
+                (TripShiftStatusDomain.FINISHED to "{}")
+
+            val error = shouldThrow<HistoricalTripSnapshotException> {
+                useCase(shiftUuid)
+            }
+
+            error.message shouldBe "Historical report is malformed"
+        }
+    }
+
+    test("throws when shift status is not historical") {
+        runTest {
+            coEvery { getShiftReportJson(shiftUuid) } returns
+                (TripShiftStatusDomain.ACTIVE to reportJson(emptyList(), moshi))
+
+            shouldThrow<HistoricalTripSnapshotException> {
+                useCase(shiftUuid)
+            }
+        }
+    }
+})
+
+private fun reportJson(carts: List<CartReport>, moshi: Moshi): String {
+    val report = ShiftReportReport(
+        tripId = TripIdReport(
+            routeId = "A-100",
+            startTime = "2026-01-01T09:00:00Z"
+        ),
+        endTime = "2026-01-01T11:00:00Z",
+        carriageId = 7,
+        carts = carts
+    )
+    return checkNotNull(moshi.adapter(ShiftReportReport::class.java).toJson(report))
+}
+
+private fun cart(
+    operationType: OperationTypeDomain,
+    employeeId: String,
+    operationTime: String,
+    vararg items: CartItemReport
+): CartReport = CartReport(
+    cartId = CartIdReport(
+        employeeId = employeeId,
+        operationTime = operationTime
+    ),
+    operationType = operationType.ordinal,
+    items = items.toList()
+)
+
+private fun item(productId: Int, quantity: Int, price: Int): CartItemReport = CartItemReport(
+    productId = productId,
+    quantity = quantity,
+    price = price
+)

--- a/app/src/test/java/com/chaikasoft/app/domain/usecases/stationUseCases/RefreshStationsOnLaunchUseCaseTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/domain/usecases/stationUseCases/RefreshStationsOnLaunchUseCaseTest.kt
@@ -9,11 +9,13 @@ import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.sealed.RefreshStationsResult
 import com.chaikasoft.app.domain.usecases.HasActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.RefreshStationsOnLaunchUseCase
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -142,6 +144,25 @@ class RefreshStationsOnLaunchUseCaseTest : FunSpec({
             val result = useCase()
 
             result shouldBe RefreshStationsResult.LocalFailure(boom)
+            coVerify(exactly = 1) { localRepo.upsertAll(stations) }
+            coVerify(exactly = 0) { syncMetaRepo.setLastSuccessfulSyncAt(any(), any()) }
+        }
+    }
+
+    test("when local upsert is cancelled - rethrows CancellationException") {
+        runTest {
+            val stations = listOf(mockk<StationDomain>())
+            val error = CancellationException("cancelled")
+            coEvery { hasActiveShift() } returns false
+            coEvery { localRepo.hasAnyStationsOnce() } returns false
+            coEvery { remoteRepo.fetchAllStations(limit = 100_000) } returns
+                RemoteResult.Success(stations)
+            coEvery { localRepo.upsertAll(stations) } throws error
+
+            shouldThrow<CancellationException> {
+                useCase()
+            }
+
             coVerify(exactly = 1) { localRepo.upsertAll(stations) }
             coVerify(exactly = 0) { syncMetaRepo.setLastSuccessfulSyncAt(any(), any()) }
         }

--- a/app/src/test/java/com/chaikasoft/app/ui/navigation/NavigationGuardsTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/navigation/NavigationGuardsTest.kt
@@ -40,6 +40,11 @@ class NavigationGuardsTest : FunSpec({
             Routes.TRIP_AUTONOMOUS,
             Routes.TRIP_BY_NUMBER,
             Routes.TRIP_SELECT_CARRIAGE,
+            Routes.HISTORY_GRAPH,
+            Routes.HISTORY_STATISTICS,
+            Routes.HISTORY_OPERATIONS,
+            Routes.historyStatistics("shift-uuid"),
+            Routes.historyOperations("shift-uuid"),
             Routes.PROFILE,
             Routes.PROFILE_GRAPH,
             Routes.PROFILE_PERSONAL_DATA,
@@ -67,5 +72,23 @@ class NavigationGuardsTest : FunSpec({
         NavigationGuards.protectedGraphForRoute(Routes.OPERATION) shouldBe
             Routes.OPERATION_GRAPH
         NavigationGuards.protectedGraphForRoute(Routes.TRIP_MAIN) shouldBe null
+    }
+
+    test("Screen.fromRoute recognizes historical dynamic routes") {
+        Screen.fromRoute(Routes.HISTORY_STATISTICS) shouldBe Screen.HistoricalStatistics
+        Screen.fromRoute(Routes.HISTORY_OPERATIONS) shouldBe Screen.HistoricalOperation
+        Screen.fromRoute(Routes.historyStatistics("shift-uuid")) shouldBe
+            Screen.HistoricalStatistics
+        Screen.fromRoute(Routes.historyOperations("shift-uuid")) shouldBe
+            Screen.HistoricalOperation
+    }
+
+    test("Screen.fromRoute recognizes exact routes and falls back to trip") {
+        Screen.fromRoute(Routes.TRIP_MAIN) shouldBe Screen.MainTrip
+        Screen.fromRoute(Routes.PRODUCT_CART) shouldBe Screen.Cart
+        Screen.fromRoute(Routes.STATISTICS) shouldBe Screen.Statistics
+        Screen.fromRoute(Routes.PROFILE_SETTINGS) shouldBe Screen.ProfileSettings
+        Screen.fromRoute("unknown-route") shouldBe Screen.Trip
+        Screen.fromRoute(null) shouldBe Screen.Trip
     }
 })

--- a/app/src/test/java/com/chaikasoft/app/ui/viewmodels/HistoricalTripViewModelTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/viewmodels/HistoricalTripViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.chaikasoft.app.ui.viewmodels
+
+import androidx.lifecycle.SavedStateHandle
+import com.chaikasoft.app.R
+import com.chaikasoft.app.domain.models.HistoricalTripSnapshot
+import com.chaikasoft.app.domain.usecases.GetHistoricalTripSnapshotUseCase
+import com.chaikasoft.app.ui.navigation.Routes
+import com.chaikasoft.app.ui.state.HistoricalTripUiState
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoricalTripViewModelTest : FunSpec({
+
+    lateinit var getHistoricalTripSnapshot: GetHistoricalTripSnapshotUseCase
+
+    val shiftUuid = "shift-uuid"
+    val savedStateHandle = SavedStateHandle(mapOf(Routes.ARG_SHIFT_UUID to shiftUuid))
+
+    beforeTest {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        getHistoricalTripSnapshot = mockk()
+    }
+
+    afterTest {
+        Dispatchers.resetMain()
+    }
+
+    test("loads historical snapshot on init") {
+        runTest {
+            val snapshot = HistoricalTripSnapshot(
+                statistics = emptyList(),
+                cashRevenue = 0,
+                cashlessChecksCount = 0,
+                operations = emptyList()
+            )
+            coEvery { getHistoricalTripSnapshot(shiftUuid) } returns snapshot
+
+            val vm = HistoricalTripViewModel(savedStateHandle, getHistoricalTripSnapshot)
+            advanceUntilIdle()
+
+            vm.uiState.value shouldBe HistoricalTripUiState.Content(snapshot)
+            coVerify(exactly = 1) { getHistoricalTripSnapshot(shiftUuid) }
+        }
+    }
+
+    test("maps snapshot loading failure to report error state") {
+        runTest {
+            coEvery { getHistoricalTripSnapshot(shiftUuid) } throws IllegalStateException("bad json")
+
+            val vm = HistoricalTripViewModel(savedStateHandle, getHistoricalTripSnapshot)
+            advanceUntilIdle()
+
+            vm.uiState.value shouldBe HistoricalTripUiState.Error(R.string.trip_finish_missing_report)
+            coVerify(exactly = 1) { getHistoricalTripSnapshot(shiftUuid) }
+        }
+    }
+
+    test("does not map snapshot loading cancellation to report error state") {
+        runTest {
+            coEvery { getHistoricalTripSnapshot(shiftUuid) } throws
+                CancellationException("cancelled")
+
+            val vm = HistoricalTripViewModel(savedStateHandle, getHistoricalTripSnapshot)
+            advanceUntilIdle()
+
+            vm.uiState.value shouldBe HistoricalTripUiState.Loading
+            coVerify(exactly = 1) { getHistoricalTripSnapshot(shiftUuid) }
+        }
+    }
+})

--- a/app/src/test/java/com/chaikasoft/app/ui/viewmodels/StatisticsViewModelTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/viewmodels/StatisticsViewModelTest.kt
@@ -57,14 +57,14 @@ class StatisticsViewModelTest : FunSpec({
         }
     }
 
-    test("refreshCartChecks updates cashChecksCount using SOLD_CART type") {
+    test("refreshCashlessChecks updates cashlessChecksCount using SOLD_CART type") {
         runTest {
             coEvery { getOperationCountByType(OperationTypeDomain.SOLD_CART) } returns 12
 
-            vm.refreshCartChecks()
+            vm.refreshCashlessChecks()
             advanceUntilIdle()
 
-            vm.cashChecksCount.value shouldBe 12
+            vm.cashlessChecksCount.value shouldBe 12
             coVerify(exactly = 1) { getOperationCountByType(OperationTypeDomain.SOLD_CART) }
         }
     }

--- a/e2e-tests/src/main/kotlin/com/chaikasoft/app/e2e/tests/HermeticSmokeE2ETest.kt
+++ b/e2e-tests/src/main/kotlin/com/chaikasoft/app/e2e/tests/HermeticSmokeE2ETest.kt
@@ -3,14 +3,32 @@
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.filters.LargeTest
+import com.chaikasoft.app.R
+import com.chaikasoft.app.data.room.AppDatabase
+import com.chaikasoft.app.data.room.repo.RoomConductorRepositoryInterface
+import com.chaikasoft.app.data.room.repo.RoomConductorTripShiftRepositoryInterface
+import com.chaikasoft.app.data.room.repo.RoomProductInfoRepositoryInterface
+import com.chaikasoft.app.data.room.repo.RoomStationRepositoryInterface
+import com.chaikasoft.app.domain.models.OperationTypeDomain
+import com.chaikasoft.app.domain.models.report.CartIdReport
+import com.chaikasoft.app.domain.models.report.CartItemReport
+import com.chaikasoft.app.domain.models.report.CartReport
+import com.chaikasoft.app.domain.models.report.ShiftReportReport
+import com.chaikasoft.app.domain.models.report.TripIdReport
+import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
+import com.chaikasoft.app.domain.models.trip.TripDomain
+import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import com.chaikasoft.app.e2e.fixtures.E2EFixtures
 import com.chaikasoft.app.e2e.rules.FailureDiagnosticsRule
 import com.chaikasoft.app.ui.activities.MainActivity
+import com.squareup.moshi.Moshi
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
@@ -24,6 +42,9 @@ import org.junit.Test
 class HermeticSmokeE2ETest {
     private companion object {
         const val SAVELOVSKAYA_CODE = "2001002"
+        const val HISTORICAL_SHIFT_UUID = "trip-e2e-history-report"
+        const val UNKNOWN_PRODUCT_ID = 404
+        const val UNKNOWN_CONDUCTOR_EMPLOYEE_ID = "E2E-404"
     }
 
     @get:Rule(order = 0)
@@ -37,6 +58,24 @@ class HermeticSmokeE2ETest {
 
     @Inject
     lateinit var startShiftUseCase: StartShiftUseCase
+
+    @Inject
+    lateinit var db: AppDatabase
+
+    @Inject
+    lateinit var stationRepository: RoomStationRepositoryInterface
+
+    @Inject
+    lateinit var productInfoRepository: RoomProductInfoRepositoryInterface
+
+    @Inject
+    lateinit var conductorRepository: RoomConductorRepositoryInterface
+
+    @Inject
+    lateinit var shiftRepository: RoomConductorTripShiftRepositoryInterface
+
+    @Inject
+    lateinit var moshi: Moshi
 
     @Before
     fun setUp() {
@@ -132,6 +171,48 @@ class HermeticSmokeE2ETest {
         composeRule.onNodeWithTag("loginButton").assertIsDisplayed()
     }
 
+    @Test
+    fun historicalTrip_opensReadOnlyStatisticsAndOperationsFromSavedReport() {
+        waitForTag("tripMainScreen")
+        seedHistoricalFinishedShift()
+
+        val historyCardTag = "historyRecordCard_$HISTORICAL_SHIFT_UUID"
+        val retryButtonTag = "historyRetrySend_$HISTORICAL_SHIFT_UUID"
+        val unknownProductName = composeRule.activity.getString(
+            R.string.historical_unknown_product_name,
+            UNKNOWN_PRODUCT_ID
+        )
+        val unknownConductorName = composeRule.activity.getString(
+            R.string.historical_unknown_conductor_name,
+            UNKNOWN_CONDUCTOR_EMPLOYEE_ID
+        )
+
+        waitForTag(historyCardTag)
+        composeRule.onNodeWithTag(retryButtonTag, useUnmergedTree = true).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(historyCardTag, useUnmergedTree = true).performClick()
+        waitForTag("statisticsScreen")
+        composeRule.onNodeWithTag("historicalBottomBarStatistics").assertIsDisplayed()
+        composeRule.onNodeWithTag("historicalBottomBarOperation").assertIsDisplayed()
+        assertTagDoesNotExist("bottomBarProduct")
+        waitForText(unknownProductName)
+
+        composeRule.onNodeWithTag("historicalBottomBarOperation").performClick()
+        waitForTag("historicalOperationScreen")
+        waitForText(unknownProductName)
+        waitForText(unknownConductorName)
+
+        composeRule.onNodeWithTag("historicalBottomBarStatistics").performClick()
+        waitForTag("statisticsScreen")
+        composeRule.onNodeWithTag("historicalBottomBarOperation").performClick()
+        waitForTag("historicalOperationScreen")
+
+        composeRule.onNodeWithContentDescription(
+            composeRule.activity.getString(R.string.btn_back)
+        ).performClick()
+        waitForTag("tripMainScreen")
+    }
+
     private fun waitForTag(tag: String, timeoutMillis: Long = 10_000L) {
         composeRule.waitUntil(timeoutMillis = timeoutMillis) {
             composeRule.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
@@ -149,6 +230,12 @@ class HermeticSmokeE2ETest {
     private fun waitForTagGone(tag: String, timeoutMillis: Long = 10_000L) {
         composeRule.waitUntil(timeoutMillis = timeoutMillis) {
             composeRule.onAllNodesWithTag(tag, useUnmergedTree = true).fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    private fun waitForText(text: String, timeoutMillis: Long = 10_000L) {
+        composeRule.waitUntil(timeoutMillis = timeoutMillis) {
+            composeRule.onAllNodesWithText(text, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
         }
     }
 
@@ -178,5 +265,71 @@ class HermeticSmokeE2ETest {
             activeCarriage = E2EFixtures.activeCarriage,
         )
         composeRule.waitForIdle()
+    }
+
+    private fun seedHistoricalFinishedShift() = runBlocking {
+        db.clearAllTables()
+        stationRepository.upsertAll(E2EFixtures.stations)
+        productInfoRepository.upsertAll(E2EFixtures.products)
+        conductorRepository.insertConductor(E2EFixtures.conductor)
+
+        val trip = E2EFixtures.trips.first().copy(
+            uuid = HISTORICAL_SHIFT_UUID,
+            trainNumber = "099A",
+        )
+        val shiftCreated = shiftRepository.tryStartNewShift(
+            ConductorTripShiftDomain(
+                trip = trip,
+                activeCarriage = E2EFixtures.activeCarriage,
+                status = TripShiftStatusDomain.ACTIVE
+            )
+        )
+        check(shiftCreated) { "Expected historical shift seed to create a fresh active shift" }
+
+        shiftRepository.updateStatusAndReport(
+            uuid = HISTORICAL_SHIFT_UUID,
+            newStatus = TripShiftStatusDomain.FINISHED.code,
+            reportJson = buildHistoricalReportJson(trip),
+            updatedAt = System.currentTimeMillis()
+        )
+        composeRule.waitForIdle()
+    }
+
+    private fun buildHistoricalReportJson(trip: TripDomain): String {
+        val report = ShiftReportReport(
+            tripId = TripIdReport(
+                routeId = trip.trainNumber,
+                startTime = trip.departure
+            ),
+            endTime = trip.arrival,
+            carriageId = E2EFixtures.activeCarriage.carNumber.toInt(),
+            carts = listOf(
+                CartReport(
+                    cartId = CartIdReport(
+                        employeeId = E2EFixtures.conductor.employeeID,
+                        operationTime = "2026-04-11T09:00:00+03:00"
+                    ),
+                    operationType = OperationTypeDomain.SOLD_CASH.ordinal,
+                    items = listOf(
+                        CartItemReport(productId = 1, quantity = -2, price = 15000)
+                    )
+                ),
+                CartReport(
+                    cartId = CartIdReport(
+                        employeeId = UNKNOWN_CONDUCTOR_EMPLOYEE_ID,
+                        operationTime = "2026-04-11T09:10:00+03:00"
+                    ),
+                    operationType = OperationTypeDomain.SOLD_CART.ordinal,
+                    items = listOf(
+                        CartItemReport(
+                            productId = UNKNOWN_PRODUCT_ID,
+                            quantity = -1,
+                            price = 9900
+                        )
+                    )
+                )
+            )
+        )
+        return moshi.adapter(ShiftReportReport::class.java).toJson(report)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Просмотр исторических статистик и операций по завершённым поездкам; навигация между ними.
  - Чтение исторического отчёта в отдельном режиме (read‑only) с отдельной нижней панелью для истории.
  - Экран подробной операции и общий снапшот поездки с отображением сводки и списка операций.

* **Bug Fixes / UX**
  - Грейс‑фолбэки для отсутствующих данных о товарах и кондукторах; улучшены сообщения об ошибках и кнопка повторной отправки.

* **Tests**
  - Добавлены юнит и e2e-тесты для исторических сценариев.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chaika-Team/ChaikaKotlin/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->