### PR TITLE
CHK-230 Aborting trips

### DIFF
--- a/app/src/main/java/com/chaikasoft/app/data/room/dao/ConductorTripShiftDao.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/dao/ConductorTripShiftDao.kt
@@ -1,6 +1,7 @@
 package com.chaikasoft.app.data.room.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -14,6 +15,9 @@ interface ConductorTripShiftDao {
 
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertNew(shift: ConductorTripShift)
+
+    @Delete
+    suspend fun deleteShift(shift: ConductorTripShift): Int
 
     @Query("SELECT * FROM conductor_trip_shifts WHERE uuid = :uuid")
     suspend fun getByUuid(uuid: String): ConductorTripShift?

--- a/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepository.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepository.kt
@@ -1,42 +1,72 @@
 package com.chaikasoft.app.data.room.repo
 
 import android.util.Log
+import androidx.room.withTransaction
+import com.chaikasoft.app.data.room.AppDatabase
+import com.chaikasoft.app.data.room.dao.CartOperationDao
 import com.chaikasoft.app.data.room.dao.ConductorTripShiftDao
 import com.chaikasoft.app.data.room.mappers.toDomain
 import com.chaikasoft.app.data.room.mappers.toEntity
 import com.chaikasoft.app.data.room.mappers.toTripShiftStatusDomain
 import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class RoomConductorTripShiftRepository @Inject constructor(private val dao: ConductorTripShiftDao) :
-    RoomConductorTripShiftRepositoryInterface {
+class RoomConductorTripShiftRepository @Inject constructor(
+    private val db: AppDatabase,
+    private val dao: ConductorTripShiftDao,
+    private val cartOperationDao: CartOperationDao
+) : RoomConductorTripShiftRepositoryInterface {
 
     /**
      * Создаёт новую ACTIVE-смену.
      *
-     * Конфликт уникальности активной смены превращается в false, чтобы доменный слой
-     * не работал с SQLite-исключением как с обычным пользовательским сценарием.
+     * Ожидаемые конфликты уникальности превращаются в типизированные результаты, чтобы
+     * доменный слой не работал с SQLite-исключением как с пользовательским сценарием.
      */
-    override suspend fun tryStartNewShift(shift: ConductorTripShiftDomain): Boolean {
+    override suspend fun tryStartNewShift(shift: ConductorTripShiftDomain): StartShiftResult {
         val entity = shift.toEntity()
-        return try {
-            dao.insertNew(entity)
-            true
-        } catch (e: android.database.sqlite.SQLiteConstraintException) {
-            Log.w(
-                "RoomConductorTripShiftRepository",
-                "Cannot start new shift! Error: ${e.message}",
-                e
-            )
-            false
+        return db.withTransaction {
+            try {
+                dao.insertNew(entity)
+                StartShiftResult.Started
+            } catch (e: android.database.sqlite.SQLiteConstraintException) {
+                Log.w(
+                    TAG,
+                    "Cannot start new shift! Error: ${e.message}",
+                    e
+                )
+                when {
+                    dao.getActiveShiftWithStations(TripShiftStatusDomain.ACTIVE.code) != null ->
+                        StartShiftResult.ActiveShiftAlreadyExists
+                    dao.getByUuid(entity.uuid) != null -> StartShiftResult.TripAlreadyRegistered
+                    else -> throw e
+                }
+            }
         }
     }
 
     override suspend fun getShiftByUuid(uuid: String): ConductorTripShiftDomain? =
         dao.getByUuidWithStations(uuid)?.toDomain()
+
+    override suspend fun deleteActiveShift(uuid: String, clearOperations: Boolean) {
+        db.withTransaction {
+            val shift = dao.getByUuid(uuid)
+                ?: throw IllegalStateException("Shift not found: $uuid")
+            check(shift.status == TripShiftStatusDomain.ACTIVE.code) {
+                "Shift uuid=$uuid is not ACTIVE"
+            }
+            check(dao.deleteShift(shift) == 1) {
+                "Shift uuid=$uuid was not deleted"
+            }
+            if (clearOperations) {
+                cartOperationDao.clearAllOperations()
+            }
+        }
+    }
 
     override suspend fun updateStatusAndReport(
         uuid: String,
@@ -60,5 +90,9 @@ class RoomConductorTripShiftRepository @Inject constructor(private val dao: Cond
         val e = dao.getByUuid(uuid)
             ?: throw IllegalStateException("Shift not found: $uuid")
         return e.status.toTripShiftStatusDomain() to e.report
+    }
+
+    private companion object {
+        const val TAG = "RoomConductorTripShiftRepository"
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryInterface.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryInterface.kt
@@ -2,6 +2,7 @@ package com.chaikasoft.app.data.room.repo
 
 import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -9,12 +10,14 @@ import kotlinx.coroutines.flow.Flow
  */
 interface RoomConductorTripShiftRepositoryInterface {
 
-    /** Вставить новую смену или обновить существующую */
-    /** Попытаться создать новую ACTIVE-смену. Возвращает false, если активная уже есть. */
-    suspend fun tryStartNewShift(shift: ConductorTripShiftDomain): Boolean
+    /** Попытаться создать новую ACTIVE-смену и вернуть типизированный результат. */
+    suspend fun tryStartNewShift(shift: ConductorTripShiftDomain): StartShiftResult
 
     /** Получить поездку по UUID */
     suspend fun getShiftByUuid(uuid: String): ConductorTripShiftDomain?
+
+    /** Удалить активную смену и при необходимости очистить операции текущего Пакета. */
+    suspend fun deleteActiveShift(uuid: String, clearOperations: Boolean)
 
     /**
      * Обновить статус и при необходимости отчёт

--- a/app/src/main/java/com/chaikasoft/app/domain/sealed/StartShiftResult.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/sealed/StartShiftResult.kt
@@ -1,0 +1,7 @@
+package com.chaikasoft.app.domain.sealed
+
+sealed interface StartShiftResult {
+    data object Started : StartShiftResult
+    data object ActiveShiftAlreadyExists : StartShiftResult
+    data object TripAlreadyRegistered : StartShiftResult
+}

--- a/app/src/main/java/com/chaikasoft/app/domain/usecases/ConductorTripShiftUseCases.kt
+++ b/app/src/main/java/com/chaikasoft/app/domain/usecases/ConductorTripShiftUseCases.kt
@@ -13,6 +13,7 @@ import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import com.chaikasoft.app.domain.sealed.SendReportResult
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.sealed.UploadResult
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -48,17 +49,20 @@ class HasActiveShiftUseCase @Inject constructor(
 
 /**
  * Пытается создать новую смену (ACTIVE) из переданных TripDomain и CarriageDomain.
- * Если в базе уже есть активная смена, ничего не делает и возвращает false.
- * Иначе создаёт новую смену со статусом ACTIVE и возвращает true.
+ * Если в базе уже есть активная смена, ничего не делает и возвращает типизированный конфликт.
+ * Иначе создаёт новую смену со статусом ACTIVE и возвращает результат репозитория.
  */
 class StartShiftUseCase @Inject constructor(
     private val repository: RoomConductorTripShiftRepositoryInterface,
     private val hasActiveShift: HasActiveShiftUseCase
 ) {
-    suspend operator fun invoke(trip: TripDomain, activeCarriage: CarriageDomain?): Boolean {
+    suspend operator fun invoke(
+        trip: TripDomain,
+        activeCarriage: CarriageDomain?
+    ): StartShiftResult {
         // не допускаем более одной активной смены
         // Быстрый путь, чтобы не ловить exception в обычном сценарии
-        if (hasActiveShift()) return false
+        if (hasActiveShift()) return StartShiftResult.ActiveShiftAlreadyExists
 
         val newShift = ConductorTripShiftDomain(
             trip = trip,
@@ -66,6 +70,18 @@ class StartShiftUseCase @Inject constructor(
             status = TripShiftStatusDomain.ACTIVE
         )
         return repository.tryStartNewShift(newShift)
+    }
+}
+
+/** Удаляет активную смену без формирования и отправки отчёта. */
+class DeleteActiveShiftUseCase @Inject constructor(
+    private val repository: RoomConductorTripShiftRepositoryInterface
+) {
+    suspend operator fun invoke(uuid: String, preservePackage: Boolean) {
+        repository.deleteActiveShift(
+            uuid = uuid,
+            clearOperations = !preservePackage
+        )
     }
 }
 

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/CurrentTripCard.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/CurrentTripCard.kt
@@ -19,9 +19,11 @@ import com.chaikasoft.app.ui.theme.TripDimens
 fun CurrentTripCard(
     modifier: Modifier = Modifier,
     tripRecord: TripDomain,
-    heightTotal: Dp = TripDimens.NewTripButtonHeight,
+    heightTotal: Dp = TripDimens.CurrentTripCardHeight,
     widthTotal: Dp = TripDimens.CardWidth,
-    onClick: () -> Unit
+    isFinishing: Boolean = false,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit
 ) {
     Box(
         modifier = modifier
@@ -38,7 +40,9 @@ fun CurrentTripCard(
             tripRecord = tripRecord,
             heightTotal = heightTotal,
             widthTotal = widthTotal,
-            onClick = onClick
+            isFinishing = isFinishing,
+            onClick = onClick,
+            onDeleteClick = onDeleteClick
         )
     }
 }
@@ -66,7 +70,8 @@ fun CurrentTripCardPreview() {
                     city = "Москва ВК Восточный"
                 )
             ),
-            onClick = { }
+            onClick = { },
+            onDeleteClick = { }
         )
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/CurrentTripContent.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/CurrentTripContent.kt
@@ -1,24 +1,33 @@
 package com.chaikasoft.app.ui.components.trip
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
@@ -29,39 +38,87 @@ import com.chaikasoft.app.ui.theme.TripDimens
 fun CurrentTripContent(
     modifier: Modifier = Modifier,
     tripRecord: TripDomain,
-    heightTotal: Dp = TripDimens.NewTripButtonHeight,
+    heightTotal: Dp = TripDimens.CurrentTripCardHeight,
     widthTotal: Dp = TripDimens.CardWidth,
-    onClick: () -> Unit
+    isFinishing: Boolean = false,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit
 ) {
     val colorScheme = MaterialTheme.colorScheme
 
-    ConstraintLayout(
+    Row(
         modifier = modifier
             .height(heightTotal)
             .width(widthTotal)
     ) {
-        val (sideRect, trainId, timeDetails, stationsDetails, button) = createRefs()
-
         SideRect(
-            modifier = Modifier
-                .constrainAs(sideRect) {
-                    start.linkTo(parent.start)
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    width = Dimension.value(TripDimens.SideRectWidth)
-                },
+            modifier = Modifier.fillMaxHeight(),
             color = colorScheme.primary
         )
 
-        Row(
+        Box(
             modifier = Modifier
-                .constrainAs(trainId) {
-                    start.linkTo(sideRect.end, margin = 4.dp)
-                    top.linkTo(parent.top)
-                    bottom.linkTo(timeDetails.top)
-                },
+                .fillMaxHeight()
+                .weight(1f)
+                .padding(
+                    start = TripDimens.CurrentTripContentPadding,
+                    end = TripDimens.CurrentTripContentPadding,
+                    bottom = TripDimens.CurrentTripContentPadding
+                )
+        ) {
+            Column(modifier = Modifier.fillMaxHeight()) {
+                CurrentTripHeader(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            end = TripDimens.IconSize + TripDimens.CurrentTripHeaderSpacing
+                        ),
+                    trainNumber = tripRecord.trainNumber
+                )
+                TimeDetails(
+                    modifier = Modifier.fillMaxWidth(),
+                    tripRecord = tripRecord
+                )
+                StationsDetails(
+                    modifier = Modifier.fillMaxWidth(),
+                    tripRecord = tripRecord
+                )
+                FinishCurrentTripButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = onClick,
+                    enabled = !isFinishing
+                )
+            }
+            TripHeaderAction(
+                modifier = Modifier.align(Alignment.TopEnd),
+                testTag = "currentTripDelete_${tripRecord.uuid}",
+                enabled = !isFinishing,
+                onClick = onDeleteClick
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(R.string.trip_delete_action),
+                    tint = if (isFinishing) {
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_ICON_ALPHA)
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentTripHeader(modifier: Modifier = Modifier, trainNumber: String) {
+    Row(
+        modifier = modifier.height(TripDimens.CurrentTripHeaderHeight),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.spacedBy(TripDimens.CurrentTripHeaderSpacing)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_train),
@@ -69,47 +126,43 @@ fun CurrentTripContent(
                 modifier = Modifier.size(TripDimens.IconSize)
             )
             Text(
-                text = tripRecord.trainNumber,
+                text = trainNumber,
                 style = MaterialTheme.typography.bodyMedium
             )
         }
-
-        TimeDetails(
-            tripRecord = tripRecord,
-            modifier = Modifier
-                .constrainAs(timeDetails) {
-                    start.linkTo(sideRect.end, margin = 4.dp)
-                    top.linkTo(trainId.bottom)
-                    end.linkTo(parent.end, margin = 4.dp)
-                    bottom.linkTo(stationsDetails.top)
-                    width = Dimension.fillToConstraints
-                }
-        )
-
-        StationsDetails(
-            tripRecord = tripRecord,
-            modifier = Modifier
-                .constrainAs(stationsDetails) {
-                    start.linkTo(sideRect.end, margin = 4.dp)
-                    top.linkTo(timeDetails.bottom)
-                    end.linkTo(parent.end, margin = 4.dp)
-                    bottom.linkTo(button.top)
-                    width = Dimension.fillToConstraints
-                }
-        )
-
-        FinishCurrentTripButton(
-            modifier = Modifier.constrainAs(button) {
-                start.linkTo(sideRect.end, margin = 4.dp)
-                top.linkTo(stationsDetails.bottom)
-                end.linkTo(parent.end, margin = 4.dp)
-                bottom.linkTo(parent.bottom, margin = 4.dp)
-                width = Dimension.fillToConstraints
-            },
-            onClick = onClick
-        )
     }
 }
+
+@Composable
+fun TripHeaderAction(
+    modifier: Modifier = Modifier,
+    testTag: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box(
+        modifier = modifier
+            .size(TripDimens.HeaderActionTouchTarget)
+            .testTag(testTag)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled,
+                role = Role.Button,
+                onClick = onClick
+            ),
+        contentAlignment = Alignment.TopEnd
+    ) {
+        Box(modifier = Modifier.size(TripDimens.IconSize)) {
+            content()
+        }
+    }
+}
+
+private const val DISABLED_ICON_ALPHA = 0.38f
 
 @Preview
 @Composable
@@ -134,7 +187,8 @@ fun CurrentTripButtonPreview() {
                     city = "Москва ВК Восточный"
                 )
             ),
-            onClick = { }
+            onClick = { },
+            onDeleteClick = { }
         )
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/DeleteTripConfirmBottomSheet.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/DeleteTripConfirmBottomSheet.kt
@@ -1,0 +1,171 @@
+package com.chaikasoft.app.ui.components.trip
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chaikasoft.app.R
+import com.chaikasoft.app.ui.viewmodels.TripViewModel
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeleteTripConfirmBottomSheet(tripViewModel: TripViewModel) {
+    val dialogState by tripViewModel.deleteTripDialog.collectAsStateWithLifecycle()
+    val dialog = dialogState ?: return
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
+
+    fun dismiss() {
+        if (dialog.isDeleting) return
+        scope.launch {
+            sheetState.hide()
+            tripViewModel.dismissDeleteTripDialog()
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = { dismiss() },
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        DeleteTripConfirmContent(
+            hasPackageItems = dialog.hasPackageItems,
+            preservePackage = dialog.preservePackage,
+            isDeleting = dialog.isDeleting,
+            errorMessageRes = dialog.errorMessageRes,
+            onPreservePackageChanged = tripViewModel::onPreservePackageChanged,
+            onConfirm = tripViewModel::confirmDeleteCurrentTrip
+        )
+    }
+}
+
+@Composable
+private fun DeleteTripConfirmContent(
+    hasPackageItems: Boolean?,
+    preservePackage: Boolean,
+    isDeleting: Boolean,
+    @StringRes errorMessageRes: Int?,
+    onPreservePackageChanged: (Boolean) -> Unit,
+    onConfirm: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("deleteTripBottomSheet")
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.trip_delete_title),
+            style = MaterialTheme.typography.titleLarge
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.trip_delete_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        PreservePackageOption(
+            visible = hasPackageItems == true,
+            preservePackage = preservePackage,
+            enabled = !isDeleting,
+            onCheckedChange = onPreservePackageChanged
+        )
+        DeleteTripError(errorMessageRes)
+        Spacer(Modifier.height(20.dp))
+        DeleteTripConfirmButton(
+            isDeleting = isDeleting,
+            enabled = hasPackageItems != null && !isDeleting,
+            onClick = onConfirm
+        )
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun PreservePackageOption(
+    visible: Boolean,
+    preservePackage: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    if (!visible) return
+
+    Spacer(Modifier.height(12.dp))
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Checkbox(
+            checked = preservePackage,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled,
+            modifier = Modifier.testTag("deleteTripPreservePackageCheckbox")
+        )
+        Text(text = stringResource(R.string.trip_delete_preserve_package))
+    }
+    Text(
+        text = stringResource(
+            if (preservePackage) {
+                R.string.trip_delete_package_restored
+            } else {
+                R.string.trip_delete_package_cleared
+            }
+        ),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+}
+
+@Composable
+private fun DeleteTripError(@StringRes errorMessageRes: Int?) {
+    if (errorMessageRes == null) return
+
+    Spacer(Modifier.height(12.dp))
+    Text(
+        text = stringResource(errorMessageRes),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.testTag("deleteTripErrorMessage")
+    )
+}
+
+@Composable
+private fun DeleteTripConfirmButton(isDeleting: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("deleteTripConfirmButton"),
+        shape = MaterialTheme.shapes.extraLarge
+    ) {
+        if (isDeleting) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                color = MaterialTheme.colorScheme.onPrimary,
+                strokeWidth = 2.dp
+            )
+        } else {
+            Text(text = stringResource(R.string.trip_delete_confirm))
+        }
+    }
+}

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/FinishCurrentTripButton.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/FinishCurrentTripButton.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import com.chaikasoft.app.R
@@ -28,7 +29,8 @@ fun FinishCurrentTripButton(
         onClick = onClick,
         modifier = modifier
             .width(TripDimens.FinishTripWidth)
-            .height(TripDimens.FinishTripHeight),
+            .height(TripDimens.FinishTripHeight)
+            .testTag("currentTripFinishButton"),
         shape = RoundedCornerShape(TripDimens.SearchBarCornerRadius),
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordCard.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordCard.kt
@@ -4,22 +4,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import com.chaikasoft.app.ui.theme.TripDimens
@@ -58,24 +48,8 @@ fun HistoryRecordCard(
                 .matchParentSize()
                 .dashedBorder(color = borderColor),
             tripRecord = tripRecord,
-            isError = isError
+            isError = isError,
+            onRetrySend = onRetrySend
         )
-
-        if (isError) {
-            IconButton(
-                onClick = onRetrySend,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-                    .padding(2.dp)
-                    .size(32.dp)
-                    .testTag("historyRetrySend_${tripRecord.uuid}")
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Refresh,
-                    contentDescription = stringResource(R.string.retry_action),
-                    tint = MaterialTheme.colorScheme.error
-                )
-            }
-        }
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordContent.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/trip/HistoryRecordContent.kt
@@ -1,10 +1,17 @@
 package com.chaikasoft.app.ui.components.trip
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -22,8 +29,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
-import androidx.constraintlayout.compose.Dimension
 import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.ui.theme.TripDimens
@@ -32,38 +37,89 @@ import com.chaikasoft.app.ui.theme.TripDimens
 fun HistoryRecordContent(
     modifier: Modifier = Modifier,
     tripRecord: TripDomain,
-    isError: Boolean = false
+    isError: Boolean = false,
+    onRetrySend: () -> Unit = {}
 ) {
     val colorScheme = MaterialTheme.colorScheme
     val sideColor = if (isError) colorScheme.error else colorScheme.secondary
+    val actionEndPadding = TripDimens.IconSize + TripDimens.HistoryRecordHeaderSpacing
 
-    ConstraintLayout(
+    Row(
         modifier = modifier
             .height(TripDimens.RecordCardHeight)
             .width(TripDimens.CardWidth)
     ) {
-        val (SideRect, trainId, timeDetails, stationsDetails) = createRefs()
-
         SideRect(
-            modifier = Modifier
-                .constrainAs(SideRect) {
-                    start.linkTo(parent.start)
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    width = Dimension.value(TripDimens.SideRectWidth)
-                },
+            modifier = Modifier.fillMaxHeight(),
             color = sideColor
         )
 
-        Row(
+        Box(
             modifier = Modifier
-                .constrainAs(trainId) {
-                    start.linkTo(SideRect.end, margin = 4.dp)
-                    top.linkTo(parent.top)
-                    bottom.linkTo(timeDetails.top)
-                },
+                .fillMaxHeight()
+                .weight(1f)
+                .padding(
+                    start = TripDimens.HistoryRecordContentPadding,
+                    end = TripDimens.HistoryRecordContentPadding,
+                    bottom = TripDimens.HistoryRecordContentPadding
+                )
+        ) {
+            Column(modifier = Modifier.fillMaxHeight()) {
+                HistoryRecordHeader(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (isError) {
+                                Modifier.padding(end = actionEndPadding)
+                            } else {
+                                Modifier
+                            }
+                        ),
+                    trainNumber = tripRecord.trainNumber,
+                    isError = isError
+                )
+                TimeDateDetails(
+                    modifier = Modifier.fillMaxWidth(),
+                    tripRecord = tripRecord
+                )
+                StationsDetails(
+                    modifier = Modifier.fillMaxWidth(),
+                    tripRecord = tripRecord
+                )
+            }
+            if (isError) {
+                TripHeaderAction(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    testTag = "historyRetrySend_${tripRecord.uuid}",
+                    onClick = onRetrySend
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = stringResource(R.string.retry_action),
+                        tint = colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryRecordHeader(
+    modifier: Modifier = Modifier,
+    trainNumber: String,
+    isError: Boolean
+) {
+    val colorScheme = MaterialTheme.colorScheme
+
+    Row(
+        modifier = modifier.height(TripDimens.HistoryRecordHeaderHeight),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.spacedBy(TripDimens.HistoryRecordHeaderSpacing)
         ) {
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_train),
@@ -72,34 +128,11 @@ fun HistoryRecordContent(
                 tint = if (isError) colorScheme.error else LocalContentColor.current
             )
             Text(
-                text = tripRecord.trainNumber,
+                text = trainNumber,
                 style = MaterialTheme.typography.bodyMedium,
                 color = if (isError) colorScheme.error else Color.Unspecified
             )
         }
-
-        TimeDateDetails(
-            tripRecord = tripRecord,
-            modifier = Modifier
-                .constrainAs(timeDetails) {
-                    start.linkTo(SideRect.end, margin = 4.dp)
-                    top.linkTo(trainId.bottom)
-                    end.linkTo(parent.end, margin = 4.dp)
-                    bottom.linkTo(stationsDetails.top)
-                    width = Dimension.fillToConstraints
-                }
-        )
-
-        StationsDetails(
-            tripRecord = tripRecord,
-            modifier = Modifier
-                .constrainAs(stationsDetails) {
-                    start.linkTo(SideRect.end, margin = 4.dp)
-                    top.linkTo(timeDetails.bottom)
-                    end.linkTo(parent.end, margin = 4.dp)
-                    width = Dimension.fillToConstraints
-                }
-        )
     }
 }
 

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/trip/AutonomousTripView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/trip/AutonomousTripView.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.collectLatest
 fun AutonomousTripScreen(viewModel: AutonomousViewModel, navController: NavController) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         viewModel.events.collectLatest { ev ->
@@ -50,7 +51,8 @@ fun AutonomousTripScreen(viewModel: AutonomousViewModel, navController: NavContr
                     }
                 }
 
-                is AutonomousViewModel.Event.Info -> snackbarHostState.showSnackbar(ev.message)
+                is AutonomousViewModel.Event.Info ->
+                    snackbarHostState.showSnackbar(context.getString(ev.messageRes))
             }
         }
     }
@@ -148,12 +150,12 @@ fun AutonomousTripScreen(viewModel: AutonomousViewModel, navController: NavContr
 
 @Composable
 private fun FocusHighlightField(
+    modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
     placeholder: String,
     imeAction: ImeAction = ImeAction.Done,
     onDone: () -> Unit = {},
-    modifier: Modifier = Modifier,
     isError: Boolean = false,
     onFocusChangedState: (Boolean) -> Unit = {}
 ) {

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/trip/MainTripView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/trip/MainTripView.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.chaikasoft.app.ui.components.trip.CurrentTripCard
+import com.chaikasoft.app.ui.components.trip.DeleteTripConfirmBottomSheet
 import com.chaikasoft.app.ui.components.trip.FinishTripConfirmBottomSheet
 import com.chaikasoft.app.ui.components.trip.FinishTripResultBottomSheet
 import com.chaikasoft.app.ui.components.trip.HistoryRecordCard
@@ -38,20 +39,20 @@ fun MainTripView(
     onFinishTripConfirmConsumed: () -> Unit = {}
 ) {
     val history by viewModel.shiftHistory.collectAsStateWithLifecycle()
-    val selectedTrip by viewModel.selectedTripRecord.collectAsStateWithLifecycle()
+    val activeTrip by viewModel.activeTripRecord.collectAsStateWithLifecycle()
+    val isFinishingTrip by viewModel.isFinishingTrip.collectAsStateWithLifecycle()
     var showFinishTripConfirmSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.loadHistory()
-        viewModel.checkActiveShift()
     }
 
     DisposableEffect(Unit) {
         onDispose { viewModel.stopHistoryObserving() }
     }
 
-    LaunchedEffect(openFinishTripConfirm, selectedTrip) {
-        if (openFinishTripConfirm && selectedTrip != null) {
+    LaunchedEffect(openFinishTripConfirm, activeTrip) {
+        if (openFinishTripConfirm && activeTrip != null) {
             showFinishTripConfirmSheet = true
             onFinishTripConfirmConsumed()
         }
@@ -88,10 +89,12 @@ fun MainTripView(
 
         HistoryToNowDivider()
 
-        if (selectedTrip != null) {
+        if (activeTrip != null) {
             CurrentTripCard(
-                tripRecord = selectedTrip!!,
+                tripRecord = activeTrip!!,
+                isFinishing = isFinishingTrip,
                 onClick = { showFinishTripConfirmSheet = true },
+                onDeleteClick = { viewModel.requestDeleteCurrentTrip() },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 24.dp, end = 24.dp, top = 6.dp, bottom = 16.dp)
@@ -117,6 +120,8 @@ fun MainTripView(
         FinishTripResultBottomSheet(
             tripViewModel = viewModel
         )
+
+        DeleteTripConfirmBottomSheet(tripViewModel = viewModel)
 
         // Retry confirmation dialog.
         RetrySendConfirmBottomSheet(tripViewModel = viewModel)

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/trip/SelectCarriageView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/trip/SelectCarriageView.kt
@@ -32,9 +32,11 @@ import com.chaikasoft.app.ui.viewmodels.TripViewModel
 
 @Composable
 fun SelectCarriageView(viewModel: TripViewModel, navController: NavController) {
-    val selectedTrip by viewModel.selectedTripRecord.collectAsStateWithLifecycle()
+    val selectedTrip by viewModel.selectedTripForCreation.collectAsStateWithLifecycle()
     val carriageNumber by viewModel.carriageNumber.collectAsStateWithLifecycle()
     val isCarriageInputValid by viewModel.isCarriageInputValid.collectAsStateWithLifecycle()
+    val startShiftErrorMessageRes by
+        viewModel.startShiftErrorMessageRes.collectAsStateWithLifecycle()
 
     Column(modifier = Modifier.fillMaxSize()) {
         when {
@@ -84,6 +86,15 @@ fun SelectCarriageView(viewModel: TripViewModel, navController: NavController) {
                             disabledIndicatorColor = Color.Transparent
                         )
                     )
+
+                    startShiftErrorMessageRes?.let { messageRes ->
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(messageRes),
+                            color = colorScheme.error,
+                            modifier = Modifier.padding(horizontal = 16.dp)
+                        )
+                    }
                 }
 
                 ButtonSurface(

--- a/app/src/main/java/com/chaikasoft/app/ui/theme/TripDimens.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/theme/TripDimens.kt
@@ -13,6 +13,14 @@ object TripDimens {
     val SideRectWidth = 24.dp
     val CornerRadius = 16.dp
     val IconSize = 24.dp
+    val CurrentTripCardHeight = 129.dp
+    val CurrentTripHeaderHeight = 24.dp
+    val HeaderActionTouchTarget = 48.dp
+    val CurrentTripContentPadding = 4.dp
+    val CurrentTripHeaderSpacing = 4.dp
+    val HistoryRecordHeaderHeight = 24.dp
+    val HistoryRecordContentPadding = 4.dp
+    val HistoryRecordHeaderSpacing = 4.dp
     val NewTripButtonHeight = 129.dp
     val NewTripButtonWidth = 327.dp
     val SearchCardHeight = 270.dp

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/AutonomousViewModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/AutonomousViewModel.kt
@@ -1,12 +1,15 @@
 package com.chaikasoft.app.ui.viewmodels
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.CarriageDomain
 import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.GetPagedStationSuggestionsUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import com.chaikasoft.app.ui.helpers.OfflineTripBuildHelper
@@ -17,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDateTime
 import java.time.ZoneId
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
@@ -104,7 +108,7 @@ class AutonomousViewModel @Inject constructor(
 
     sealed interface Event {
         data class ShiftStarted(val trip: TripDomain, val carriage: CarriageDomain) : Event
-        data class Info(val message: String) : Event
+        data class Info(@StringRes val messageRes: Int) : Event
     }
 
     private val _events = MutableSharedFlow<Event>()
@@ -164,6 +168,7 @@ class AutonomousViewModel @Inject constructor(
 
     fun onCarriageClassTypeChange(value: String) = update { copy(carriageClassType = value) }
 
+    @Suppress("TooGenericExceptionCaught")
     fun submit(zone: ZoneId = ZoneId.systemDefault()) {
         val current = _state.value
         val input = Input(
@@ -188,17 +193,26 @@ class AutonomousViewModel @Inject constructor(
 
                 is BuildResult.Failure -> {
                     update { copy(isSubmitting = false, lastMessage = result.cause.message) }
-                    _events.emit(Event.Info(result.cause.message ?: "Не удалось собрать поездку"))
+                    _events.emit(Event.Info(R.string.start_shift_failed))
                 }
 
                 is BuildResult.Success -> {
                     val (trip, carriage) = result.output
-                    val started = runCatching { startShift(trip, carriage) }.getOrElse { false }
+                    val startResult = try {
+                        startShift(trip, carriage)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Exception) {
+                        null
+                    }
                     update { copy(isSubmitting = false) }
-                    if (started) {
-                        _events.emit(Event.ShiftStarted(trip, carriage))
-                    } else {
-                        _events.emit(Event.Info("Уже есть активная смена"))
+                    when (startResult) {
+                        StartShiftResult.Started -> _events.emit(Event.ShiftStarted(trip, carriage))
+                        StartShiftResult.ActiveShiftAlreadyExists ->
+                            _events.emit(Event.Info(R.string.active_shift_already_exists))
+                        StartShiftResult.TripAlreadyRegistered ->
+                            _events.emit(Event.Info(R.string.trip_already_registered))
+                        null -> _events.emit(Event.Info(R.string.start_shift_failed))
                     }
                 }
             }

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/TripViewModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/TripViewModel.kt
@@ -3,13 +3,17 @@ package com.chaikasoft.app.ui.viewmodels
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.CarriageDomain
 import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.CompleteShiftAndSendUseCase
+import com.chaikasoft.app.domain.usecases.DeleteActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.GetActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.GetPagedStationSuggestionsUseCase
 import com.chaikasoft.app.domain.usecases.GetShiftHistoryUseCase
+import com.chaikasoft.app.domain.usecases.HasAnyPackageItemsOnceUseCase
 import com.chaikasoft.app.domain.usecases.SearchTripsByStationsUseCase
 import com.chaikasoft.app.domain.usecases.SendShiftReportUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
@@ -21,6 +25,10 @@ import com.chaikasoft.app.ui.viewmodels.delegates.TripSearchDelegate
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -30,6 +38,8 @@ class TripViewModel @Inject constructor(
     startShiftUseCase: StartShiftUseCase,
     getActiveShiftUseCase: GetActiveShiftUseCase,
     completeShiftUseCase: CompleteShiftAndSendUseCase,
+    deleteActiveShiftUseCase: DeleteActiveShiftUseCase,
+    hasAnyPackageItemsOnceUseCase: HasAnyPackageItemsOnceUseCase,
     getShiftHistoryUseCase: GetShiftHistoryUseCase,
     sendShiftReportUseCase: SendShiftReportUseCase
 ) : ViewModel() {
@@ -44,6 +54,8 @@ class TripViewModel @Inject constructor(
         startShiftUseCase,
         getActiveShiftUseCase,
         completeShiftUseCase,
+        deleteActiveShiftUseCase,
+        hasAnyPackageItemsOnceUseCase,
         viewModelScope
     )
 
@@ -80,20 +92,30 @@ class TripViewModel @Inject constructor(
 
     /* -------- facade: shift and carriage -------- */
 
-    val selectedTripRecord = shift.selectedTrip
+    val selectedTripForCreation = shift.selectedTripForCreation
+    val activeTripRecord = shift.activeTrip
+    val isFinishingTrip = shift.isFinishing
     val finishTripDialog = shift.finishDialog
+    val deleteTripDialog = shift.deleteDialog
 
     val carriageNumber = carriageInput.number
     val isCarriageInputValid = carriageInput.isValid
+    private val _startShiftErrorMessageRes = MutableStateFlow<Int?>(null)
+    val startShiftErrorMessageRes: StateFlow<Int?> = _startShiftErrorMessageRes.asStateFlow()
 
     fun onCarriageNumberChanged(raw: String) = carriageInput.onNumberChanged(raw)
     fun dismissFinishTripDialog() = shift.dismissFinishDialog()
-    fun checkActiveShift() = shift.checkActiveShift()
     fun finishCurrentTrip() = shift.finishCurrentTrip()
+    fun requestDeleteCurrentTrip() = shift.requestDeleteCurrentTrip()
+    fun onPreservePackageChanged(preservePackage: Boolean) =
+        shift.onPreservePackageChanged(preservePackage)
+    fun confirmDeleteCurrentTrip() = shift.confirmDeleteCurrentTrip()
+    fun dismissDeleteTripDialog() = shift.dismissDeleteDialog()
 
     fun selectTrip(trip: TripDomain) {
         shift.selectTrip(trip)
         carriageInput.reset()
+        _startShiftErrorMessageRes.value = null
     }
 
     /* -------- facade: history and retry -------- */
@@ -139,24 +161,38 @@ class TripViewModel @Inject constructor(
         suggestions.onToQueryChanged(station?.name.orEmpty())
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun confirmCarriageInput(onSuccess: () -> Unit) {
-        val trip = shift.selectedTrip.value ?: return
+        val trip = shift.selectedTripForCreation.value ?: return
         val number = carriageInput.validatedNumber ?: run {
             Log.e(TAG, "Invalid carriage number: ${carriageInput.number.value}")
             return
         }
 
+        _startShiftErrorMessageRes.value = null
         viewModelScope.launch {
             try {
                 val carriage = CarriageDomain(
                     carNumber = number.toString(),
                     classType = ""
                 )
-                shift.startShift(trip, carriage)
-                shift.checkActiveShift()
-                onSuccess()
+                when (shift.startShift(trip, carriage)) {
+                    StartShiftResult.Started,
+                    StartShiftResult.ActiveShiftAlreadyExists -> {
+                        shift.clearSelectedTripForCreation()
+                        onSuccess()
+                    }
+                    StartShiftResult.TripAlreadyRegistered ->
+                        _startShiftErrorMessageRes.value = R.string.trip_already_registered
+                }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: IOException) {
                 Log.e(TAG, "Error confirming carriage input", e)
+                _startShiftErrorMessageRes.value = R.string.start_shift_failed
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "Error confirming carriage input", e)
+                _startShiftErrorMessageRes.value = R.string.start_shift_failed
             }
         }
     }

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/delegates/ShiftDelegate.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/delegates/ShiftDelegate.kt
@@ -7,82 +7,92 @@ import com.chaikasoft.app.domain.models.trip.CarriageDomain
 import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.sealed.SendReportResult
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.CompleteShiftAndSendUseCase
+import com.chaikasoft.app.domain.usecases.DeleteActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.GetActiveShiftUseCase
+import com.chaikasoft.app.domain.usecases.HasAnyPackageItemsOnceUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class ShiftDelegate(
     private val startShiftUseCase: StartShiftUseCase,
     private val getActiveShiftUseCase: GetActiveShiftUseCase,
     private val completeShiftUseCase: CompleteShiftAndSendUseCase,
+    private val deleteActiveShiftUseCase: DeleteActiveShiftUseCase,
+    private val hasAnyPackageItemsOnceUseCase: HasAnyPackageItemsOnceUseCase,
     private val scope: CoroutineScope
 ) {
 
     data class FinishTripDialog(@StringRes val messageRes: Int)
 
-    private val _selectedTrip = MutableStateFlow<TripDomain?>(null)
-    val selectedTrip: StateFlow<TripDomain?> = _selectedTrip.asStateFlow()
+    data class DeleteTripDialog(
+        val tripUuid: String,
+        val hasPackageItems: Boolean? = null,
+        val preservePackage: Boolean = true,
+        val isDeleting: Boolean = false,
+        @StringRes val errorMessageRes: Int? = null
+    )
 
-    private val selectedCarriage = MutableStateFlow<CarriageDomain?>(null)
+    private val _selectedTripForCreation = MutableStateFlow<TripDomain?>(null)
+    val selectedTripForCreation: StateFlow<TripDomain?> = _selectedTripForCreation.asStateFlow()
 
-    private val _shiftStatus = MutableStateFlow<Boolean?>(null)
-    val shiftStatus: StateFlow<Boolean?> = _shiftStatus.asStateFlow()
-
-    private val activeShift = MutableStateFlow<ConductorTripShiftDomain?>(null)
+    private val activeShift: StateFlow<ConductorTripShiftDomain?> =
+        getActiveShiftUseCase()
+            .distinctUntilChanged()
+            .catch { e ->
+                Log.e(TAG, "Failed to observe active shift", e)
+                emit(null)
+            }
+            .stateIn(scope, SharingStarted.Eagerly, null)
+    val activeTrip: StateFlow<TripDomain?> =
+        activeShift
+            .map { shift -> shift?.trip }
+            .distinctUntilChanged()
+            .stateIn(scope, SharingStarted.Eagerly, null)
 
     private val _finishDialog = MutableStateFlow<FinishTripDialog?>(null)
     val finishDialog: StateFlow<FinishTripDialog?> = _finishDialog.asStateFlow()
+    private val _isFinishing = MutableStateFlow(false)
+    val isFinishing: StateFlow<Boolean> = _isFinishing.asStateFlow()
+
+    private val _deleteDialog = MutableStateFlow<DeleteTripDialog?>(null)
+    val deleteDialog: StateFlow<DeleteTripDialog?> = _deleteDialog.asStateFlow()
+    private var packageInspectionJob: Job? = null
 
     fun selectTrip(trip: TripDomain) {
-        _selectedTrip.value = trip
+        _selectedTripForCreation.value = trip
         Log.d(TAG, "Selected trip: ${trip.uuid}")
     }
 
-    suspend fun startShift(trip: TripDomain, carriage: CarriageDomain): Boolean = try {
-        selectedCarriage.value = carriage
-        val ok = startShiftUseCase(trip, carriage)
-        _shiftStatus.value = ok
-        Log.d(TAG, if (ok) "Shift started" else "Shift start failed")
-        ok
-    } catch (e: IllegalArgumentException) {
-        _shiftStatus.value = false
-        Log.e(TAG, "Failed to start shift", e)
-        false
+    fun clearSelectedTripForCreation() {
+        _selectedTripForCreation.value = null
     }
 
-    fun checkActiveShift() {
-        scope.launch {
-            try {
-                val shift = getActiveShiftUseCase().first()
-                activeShift.value = shift
-                if (shift == null) {
-                    _selectedTrip.value = null
-                    selectedCarriage.value = null
-                    _shiftStatus.value = false
-                } else {
-                    _selectedTrip.value = shift.trip
-                    selectedCarriage.value = shift.activeCarriage
-                    _shiftStatus.value = true
-                }
-                Log.d(TAG, if (shift != null) "Active shift found" else "No active shift")
-            } catch (e: IOException) {
-                Log.e(TAG, "Failed to check active shift", e)
-            }
-        }
+    suspend fun startShift(trip: TripDomain, carriage: CarriageDomain): StartShiftResult {
+        val result = startShiftUseCase(trip, carriage)
+        Log.d(TAG, "Shift start result: $result")
+        return result
     }
 
+    @Suppress("TooGenericExceptionCaught")
     fun finishCurrentTrip() {
-        val trip = _selectedTrip.value ?: return
-        _selectedTrip.value = null
-        selectedCarriage.value = null
+        val trip = activeTrip.value ?: return
+        if (_isFinishing.value || _deleteDialog.value != null) return
 
+        _isFinishing.value = true
         scope.launch {
             try {
                 val msg = when (completeShiftUseCase(trip.uuid)) {
@@ -93,15 +103,88 @@ class ShiftDelegate(
                     is SendReportResult.PermanentFailure -> R.string.trip_finish_perm_failure
                 }
                 _finishDialog.value = FinishTripDialog(msg)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: IOException) {
                 Log.e(TAG, "Error finishing trip", e)
                 _finishDialog.value = FinishTripDialog(R.string.trip_finish_temp_failure)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "Error finishing trip", e)
+                _finishDialog.value = FinishTripDialog(R.string.trip_finish_temp_failure)
+            } finally {
+                _isFinishing.value = false
             }
         }
     }
 
     fun dismissFinishDialog() {
         _finishDialog.value = null
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    fun requestDeleteCurrentTrip() {
+        val trip = activeTrip.value ?: return
+        if (_isFinishing.value || _deleteDialog.value != null) return
+
+        val pendingDialog = DeleteTripDialog(tripUuid = trip.uuid)
+        _deleteDialog.value = pendingDialog
+        packageInspectionJob?.cancel()
+        packageInspectionJob = scope.launch {
+            try {
+                val hasPackageItems = hasAnyPackageItemsOnceUseCase()
+                if (_deleteDialog.value === pendingDialog) {
+                    _deleteDialog.value = pendingDialog.copy(hasPackageItems = hasPackageItems)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "Failed to inspect package before deleting shift", e)
+                if (_deleteDialog.value === pendingDialog) {
+                    _deleteDialog.value = pendingDialog.copy(
+                        errorMessageRes = R.string.trip_delete_failure
+                    )
+                }
+            }
+        }
+    }
+
+    fun onPreservePackageChanged(preservePackage: Boolean) {
+        val dialog = _deleteDialog.value ?: return
+        if (dialog.hasPackageItems != true || dialog.isDeleting) return
+        _deleteDialog.value = dialog.copy(preservePackage = preservePackage)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    fun confirmDeleteCurrentTrip() {
+        val dialog = _deleteDialog.value ?: return
+        val hasPackageItems = dialog.hasPackageItems ?: return
+        if (_isFinishing.value || dialog.isDeleting) return
+
+        _deleteDialog.value = dialog.copy(isDeleting = true, errorMessageRes = null)
+        scope.launch {
+            try {
+                deleteActiveShiftUseCase(
+                    uuid = dialog.tripUuid,
+                    preservePackage = hasPackageItems && dialog.preservePackage
+                )
+                _deleteDialog.value = null
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "Failed to delete shift: ${dialog.tripUuid}", e)
+                _deleteDialog.value = dialog.copy(
+                    isDeleting = false,
+                    errorMessageRes = R.string.trip_delete_failure
+                )
+            }
+        }
+    }
+
+    fun dismissDeleteDialog() {
+        if (_deleteDialog.value?.isDeleting == true) return
+        packageInspectionJob?.cancel()
+        packageInspectionJob = null
+        _deleteDialog.value = null
     }
 
     private companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,14 @@
     <string name="no_selected_trip_error">Ошибка загрузки выбранного маршрута</string>
     <string name="carriage_class">Класс</string>
     <string name="finish_trip">ЗАВЕРШИТЬ</string>
+    <string name="trip_delete_action">Удалить поездку</string>
+    <string name="trip_delete_title">Удаление поездки</string>
+    <string name="trip_delete_subtitle">Вы уверены, что хотите удалить поездку?</string>
+    <string name="trip_delete_preserve_package">Сохранить пакет</string>
+    <string name="trip_delete_package_cleared">Текущий Пакет будет очищен</string>
+    <string name="trip_delete_package_restored">Текущий Пакет будет восстановлен при создании новой поездки</string>
+    <string name="trip_delete_confirm">УДАЛИТЬ ПОЕЗДКУ</string>
+    <string name="trip_delete_failure">Не удалось удалить поездку. Попробуйте ещё раз</string>
     <string name="retry_action">Повторить</string>
     <string name="loading_error_message">Ошибка загрузки: %1$s</string>
     <string name="empty_carriages_message">Нет доступных вагонов</string>
@@ -45,6 +53,8 @@
     <string name="start_shift_btn">Начать смену</string>
     <string name="start_shift_success">Смена начата</string>
     <string name="start_shift_failed">Не удалось начать смену</string>
+    <string name="active_shift_already_exists">Уже есть активная смена</string>
+    <string name="trip_already_registered">Поездка уже была зарегистрирована</string>
 
     <!-- Ошибки валидации -->
     <string name="err_train_number_empty">Укажите номер поезда</string>

--- a/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryTest.kt
@@ -4,9 +4,6 @@ import com.chaikasoft.app.data.room.dao.ConductorTripShiftDao
 import com.chaikasoft.app.data.room.entities.ConductorTripShift
 import com.chaikasoft.app.data.room.entities.Station
 import com.chaikasoft.app.data.room.relations.ConductorTripShiftWithStations
-import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
-import com.chaikasoft.app.domain.models.trip.StationDomain
-import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -25,19 +22,11 @@ class RoomConductorTripShiftRepositoryTest : FunSpec({
 
     beforeTest {
         dao = mockk(relaxed = true)
-        repository = RoomConductorTripShiftRepository(dao)
-    }
-
-    test("tryStartNewShift returns false on SQLiteConstraintException and true on success") {
-        runTest {
-            val shift = sampleDomainShift("uuid-2")
-
-            coEvery { dao.insertNew(any()) } throws android.database.sqlite.SQLiteConstraintException("conflict")
-            repository.tryStartNewShift(shift) shouldBe false
-
-            coEvery { dao.insertNew(any()) } returns Unit
-            repository.tryStartNewShift(shift) shouldBe true
-        }
+        repository = RoomConductorTripShiftRepository(
+            db = mockk(relaxed = true),
+            dao = dao,
+            cartOperationDao = mockk(relaxed = true)
+        )
     }
 
     test("getStatusAndReport throws when shift is missing") {
@@ -65,20 +54,6 @@ class RoomConductorTripShiftRepositoryTest : FunSpec({
     }
 }) {
     companion object {
-        private fun sampleDomainShift(uuid: String) = ConductorTripShiftDomain(
-            trip = TripDomain(
-                uuid = uuid,
-                trainNumber = "100A",
-                departure = "2026-03-09T10:00:00Z",
-                arrival = "2026-03-09T14:00:00Z",
-                duration = "PT4H",
-                from = StationDomain("MSK", "Moscow", "Moscow"),
-                to = StationDomain("TVE", "Tver", "Tver"),
-            ),
-            activeCarriage = null,
-            status = TripShiftStatusDomain.ACTIVE,
-        )
-
         private fun sampleRelationShift(
             uuid: String,
             status: TripShiftStatusDomain,

--- a/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryTransactionTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomConductorTripShiftRepositoryTransactionTest.kt
@@ -1,0 +1,263 @@
+package com.chaikasoft.app.data.room.repo
+
+import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chaikasoft.app.data.room.AppDatabase
+import com.chaikasoft.app.data.room.dao.CartOperationDao
+import com.chaikasoft.app.data.room.entities.CartItem
+import com.chaikasoft.app.data.room.entities.CartOperation
+import com.chaikasoft.app.data.room.entities.Conductor
+import com.chaikasoft.app.data.room.entities.ConductorTripShift
+import com.chaikasoft.app.data.room.entities.ProductInfo
+import com.chaikasoft.app.data.room.entities.Station
+import com.chaikasoft.app.domain.models.OperationTypeDomain
+import com.chaikasoft.app.domain.models.trip.CarriageDomain
+import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
+import com.chaikasoft.app.domain.models.trip.StationDomain
+import com.chaikasoft.app.domain.models.trip.TripDomain
+import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
+import io.mockk.coEvery
+import io.mockk.spyk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RoomConductorTripShiftRepositoryTransactionTest {
+
+    private lateinit var db: AppDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        db.openHelper.writableDatabase.execSQL(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_active_shift
+            ON conductor_trip_shifts(status)
+            WHERE status = ${TripShiftStatusDomain.ACTIVE.code}
+            """.trimIndent()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun deleteActiveShift_withoutClearingOperations_preservesPackage() = runTest {
+        seedActiveShift()
+        seedOperationWithItem()
+
+        createRepository().deleteActiveShift(UUID, clearOperations = false)
+
+        assertNull(db.conductorTripShiftDao().getByUuid(UUID))
+        assertEquals(1, db.cartOperationDao().getAllOperations().first().size)
+        assertEquals(1, db.cartItemDao().getAllCartItems().first().size)
+    }
+
+    @Test
+    fun tryStartNewShift_freshTrip_returnsStarted() = runTest {
+        seedStations()
+
+        val result = createRepository().tryStartNewShift(sampleDomainShift(UUID))
+
+        assertEquals(StartShiftResult.Started, result)
+        assertNotNull(db.conductorTripShiftDao().getByUuid(UUID))
+    }
+
+    @Test
+    fun tryStartNewShift_activeShiftExists_returnsActiveConflict() = runTest {
+        seedActiveShift()
+
+        val result = createRepository().tryStartNewShift(sampleDomainShift("another-trip"))
+
+        assertEquals(StartShiftResult.ActiveShiftAlreadyExists, result)
+        assertNull(db.conductorTripShiftDao().getByUuid("another-trip"))
+    }
+
+    @Test
+    fun tryStartNewShift_finishedTripWithSameUuid_returnsRegisteredConflict() = runTest {
+        seedActiveShift()
+        db.conductorTripShiftDao().updateStatusAndReport(
+            uuid = UUID,
+            newStatus = TripShiftStatusDomain.FINISHED.code,
+            reportJson = "{}",
+            updatedAt = 2L
+        )
+
+        val result = createRepository().tryStartNewShift(sampleDomainShift(UUID))
+
+        assertEquals(StartShiftResult.TripAlreadyRegistered, result)
+        val history = db.conductorTripShiftDao().getHistoryWithStations().first()
+        assertEquals(1, history.size)
+        assertEquals(TripShiftStatusDomain.FINISHED.code, history.single().shift.status)
+        assertEquals("{}", history.single().shift.report)
+    }
+
+    @Test
+    fun tryStartNewShift_unknownConstraint_rethrows() = runTest {
+        seedStations()
+        val invalidShift = sampleDomainShift(UUID).copy(
+            trip = sampleDomainShift(UUID).trip.copy(
+                from = StationDomain(code = "MISSING", name = "Missing", city = "Missing")
+            )
+        )
+
+        try {
+            createRepository().tryStartNewShift(invalidShift)
+            fail("Expected SQLiteConstraintException")
+        } catch (_: SQLiteConstraintException) {
+        }
+    }
+
+    @Test
+    fun deleteActiveShift_withClearingOperations_removesPackage() = runTest {
+        seedActiveShift()
+        seedOperationWithItem()
+
+        createRepository().deleteActiveShift(UUID, clearOperations = true)
+
+        assertNull(db.conductorTripShiftDao().getByUuid(UUID))
+        assertEquals(emptyList<CartOperation>(), db.cartOperationDao().getAllOperations().first())
+        assertEquals(emptyList<CartItem>(), db.cartItemDao().getAllCartItems().first())
+    }
+
+    @Test
+    fun deleteActiveShift_finishedShift_throwsAndPreservesShift() = runTest {
+        seedActiveShift(status = TripShiftStatusDomain.FINISHED)
+
+        try {
+            createRepository().deleteActiveShift(UUID, clearOperations = true)
+            fail("Expected IllegalStateException")
+        } catch (_: IllegalStateException) {
+        }
+
+        assertNotNull(db.conductorTripShiftDao().getByUuid(UUID))
+    }
+
+    @Test
+    fun deleteActiveShift_clearFailure_rollsBackShiftDeletion() = runTest {
+        seedActiveShift()
+        seedOperationWithItem()
+        val failingCartOperationDao = spyk(db.cartOperationDao())
+        coEvery {
+            failingCartOperationDao.clearAllOperations()
+        } throws IllegalStateException("clear failed")
+
+        try {
+            createRepository(failingCartOperationDao).deleteActiveShift(UUID, clearOperations = true)
+            fail("Expected IllegalStateException")
+        } catch (_: IllegalStateException) {
+        }
+
+        assertNotNull(db.conductorTripShiftDao().getByUuid(UUID))
+        assertEquals(1, db.cartOperationDao().getAllOperations().first().size)
+        assertEquals(1, db.cartItemDao().getAllCartItems().first().size)
+    }
+
+    private fun createRepository(
+        cartOperationDao: CartOperationDao = db.cartOperationDao()
+    ): RoomConductorTripShiftRepository = RoomConductorTripShiftRepository(
+        db = db,
+        dao = db.conductorTripShiftDao(),
+        cartOperationDao = cartOperationDao
+    )
+
+    private suspend fun seedActiveShift(status: TripShiftStatusDomain = TripShiftStatusDomain.ACTIVE) {
+        seedStations()
+        db.conductorTripShiftDao().insertNew(
+            ConductorTripShift(
+                uuid = UUID,
+                trainNumber = "TN-01",
+                departure = "2025-01-01T00:00:00Z",
+                arrival = "2025-01-01T10:00:00Z",
+                duration = "PT10H",
+                fromCode = "STA",
+                toCode = "STB",
+                activeCarriage = CarriageDomain("12", "2A"),
+                status = status.code,
+                report = null,
+                createdAt = 1L,
+                updatedAt = null
+            )
+        )
+    }
+
+    private suspend fun seedStations() {
+        db.stationDao().upsertAll(
+            listOf(
+                Station(code = "STA", name = "Start", city = "CityA"),
+                Station(code = "STB", name = "End", city = "CityB")
+            )
+        )
+    }
+
+    private fun sampleDomainShift(uuid: String) = ConductorTripShiftDomain(
+        trip = TripDomain(
+            uuid = uuid,
+            trainNumber = "TN-01",
+            departure = "2025-01-01T00:00:00Z",
+            arrival = "2025-01-01T10:00:00Z",
+            duration = "PT10H",
+            from = StationDomain(code = "STA", name = "Start", city = "CityA"),
+            to = StationDomain(code = "STB", name = "End", city = "CityB")
+        ),
+        activeCarriage = CarriageDomain("12", "2A"),
+        status = TripShiftStatusDomain.ACTIVE
+    )
+
+    private suspend fun seedOperationWithItem() {
+        db.conductorDao().insertConductor(
+            Conductor(
+                id = 7,
+                name = "Ivan",
+                familyName = "Petrov",
+                givenName = "Ivanovich",
+                employeeID = "EMP-7",
+                image = "img"
+            )
+        )
+        db.productInfoDao().insertProduct(
+            ProductInfo(
+                id = 100,
+                name = "Tea",
+                description = "Black",
+                image = "img",
+                price = 150
+            )
+        )
+        val operationId = db.cartOperationDao().insertOperation(
+            CartOperation(
+                operationType = OperationTypeDomain.ADD.ordinal,
+                operationTime = "2025-01-01T02:00:00Z",
+                conductorId = 7
+            )
+        ).toInt()
+        db.cartItemDao().insertCartItem(
+            CartItem(
+                cartOperationId = operationId,
+                productId = 100,
+                impact = 3
+            )
+        )
+    }
+
+    private companion object {
+        const val UUID = "trip-delete-uuid"
+    }
+}

--- a/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomShiftReportRepositoryTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/data/room/repo/RoomShiftReportRepositoryTest.kt
@@ -18,6 +18,9 @@ import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
 import com.squareup.moshi.Moshi
 import io.mockk.coEvery
 import io.mockk.spyk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -81,6 +84,32 @@ class RoomShiftReportRepositoryTest {
         assertEquals(100, parsed?.carts?.first()?.items?.first()?.productId)
         assertEquals(-2, parsed?.carts?.first()?.items?.first()?.quantity)
         assertEquals(150, parsed?.carts?.first()?.items?.first()?.price)
+    }
+
+    @Test
+    fun finishShiftWithReport_emitsNoActiveShiftAndFinishedHistory() = runTest {
+        seedActiveShift()
+        seedOperationWithItem(productId = 100, impact = -2)
+        val repository = createRepository()
+        val dao = db.conductorTripShiftDao()
+        val activeAfterFinish = async(start = CoroutineStart.UNDISPATCHED) {
+            dao.getActiveShiftWithStationsFlow(TripShiftStatusDomain.ACTIVE.code)
+                .drop(1)
+                .first()
+        }
+        val historyAfterFinish = async(start = CoroutineStart.UNDISPATCHED) {
+            dao.getHistoryWithStations()
+                .drop(1)
+                .first()
+        }
+
+        repository.finishShiftWithReport(UUID)
+
+        assertNull(activeAfterFinish.await())
+        val history = historyAfterFinish.await()
+        assertEquals(1, history.size)
+        assertEquals(UUID, history.single().shift.uuid)
+        assertEquals(TripShiftStatusDomain.FINISHED.code, history.single().shift.status)
     }
 
     /**

--- a/app/src/test/java/com/chaikasoft/app/domain/usecases/conductorTripShiftUseCases/DeleteActiveShiftUseCaseTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/domain/usecases/conductorTripShiftUseCases/DeleteActiveShiftUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.chaikasoft.app.domain.usecases.conductorTripShiftUseCases
+
+import com.chaikasoft.app.data.room.repo.RoomConductorTripShiftRepositoryInterface
+import com.chaikasoft.app.domain.usecases.DeleteActiveShiftUseCase
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+
+class DeleteActiveShiftUseCaseTest : FunSpec({
+
+    lateinit var repository: RoomConductorTripShiftRepositoryInterface
+    lateinit var useCase: DeleteActiveShiftUseCase
+
+    beforeTest {
+        repository = mockk()
+        useCase = DeleteActiveShiftUseCase(repository)
+    }
+
+    test("preserve package keeps operations") {
+        runTest {
+            coEvery { repository.deleteActiveShift(UUID, clearOperations = false) } returns Unit
+
+            useCase(UUID, preservePackage = true)
+
+            coVerify(exactly = 1) {
+                repository.deleteActiveShift(UUID, clearOperations = false)
+            }
+            confirmVerified(repository)
+        }
+    }
+
+    test("do not preserve package clears operations") {
+        runTest {
+            coEvery { repository.deleteActiveShift(UUID, clearOperations = true) } returns Unit
+
+            useCase(UUID, preservePackage = false)
+
+            coVerify(exactly = 1) {
+                repository.deleteActiveShift(UUID, clearOperations = true)
+            }
+            confirmVerified(repository)
+        }
+    }
+}) {
+    companion object {
+        private const val UUID = "trip-uuid-123"
+    }
+}

--- a/app/src/test/java/com/chaikasoft/app/domain/usecases/conductorTripShiftUseCases/StartShiftUseCaseTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/domain/usecases/conductorTripShiftUseCases/StartShiftUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.StationDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.HasActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import io.kotest.core.spec.style.FunSpec
@@ -50,17 +51,17 @@ class StartShiftUseCaseTest : FunSpec({
      * Описание:
      *   - Эквивалентный класс входных данных: активная смена уже существует.
      *   - Ожидаемое поведение:
-     *       1) юзкейс возвращает false,
+     *       1) юзкейс возвращает типизированный конфликт,
      *       2) не пытается создать новую смену (tryStartNewShift не вызывается).
      *   - Цель: зафиксировать инвариант "не более одной ACTIVE-смены".
      */
-    test("when active shift already exists - returns false and does not start new shift") {
+    test("when active shift already exists - returns conflict and does not start new shift") {
         runTest {
             coEvery { hasActiveShift() } returns true
 
             val result = useCase(trip, carriage)
 
-            result shouldBe false
+            result shouldBe StartShiftResult.ActiveShiftAlreadyExists
 
             coVerify(exactly = 1) { hasActiveShift() }
             coVerify(exactly = 0) { repository.tryStartNewShift(any()) }
@@ -86,11 +87,13 @@ class StartShiftUseCaseTest : FunSpec({
         runTest {
             val shiftSlot = slot<ConductorTripShiftDomain>()
             coEvery { hasActiveShift() } returns false
-            coEvery { repository.tryStartNewShift(capture(shiftSlot)) } returns true
+            coEvery {
+                repository.tryStartNewShift(capture(shiftSlot))
+            } returns StartShiftResult.Started
 
             val result = useCase(trip, carriage)
 
-            result shouldBe true
+            result shouldBe StartShiftResult.Started
             shiftSlot.captured.trip shouldBe trip
             shiftSlot.captured.activeCarriage shouldBe carriage
             shiftSlot.captured.status shouldBe TripShiftStatusDomain.ACTIVE
@@ -118,11 +121,13 @@ class StartShiftUseCaseTest : FunSpec({
         runTest {
             val shiftSlot = slot<ConductorTripShiftDomain>()
             coEvery { hasActiveShift() } returns false
-            coEvery { repository.tryStartNewShift(capture(shiftSlot)) } returns false
+            coEvery {
+                repository.tryStartNewShift(capture(shiftSlot))
+            } returns StartShiftResult.TripAlreadyRegistered
 
             val result = useCase(trip, null)
 
-            result shouldBe false
+            result shouldBe StartShiftResult.TripAlreadyRegistered
             shiftSlot.captured.trip shouldBe trip
             shiftSlot.captured.activeCarriage shouldBe null
             shiftSlot.captured.status shouldBe TripShiftStatusDomain.ACTIVE

--- a/app/src/test/java/com/chaikasoft/app/ui/viewmodels/AutonomousViewModelTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/viewmodels/AutonomousViewModelTest.kt
@@ -2,7 +2,9 @@ package com.chaikasoft.app.ui.viewmodels
 
 import androidx.paging.PagingData
 import app.cash.turbine.test
+import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.trip.StationDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.GetPagedStationSuggestionsUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import com.chaikasoft.app.ui.helpers.OfflineTripBuildHelper
@@ -37,7 +39,7 @@ class AutonomousViewModelTest : FunSpec({
         every {
             getPagedStationSuggestions(any(), any())
         } returns flowOf(PagingData.empty<StationDomain>())
-        coEvery { startShift(any(), any()) } returns true
+        coEvery { startShift(any(), any()) } returns StartShiftResult.Started
 
         vm = AutonomousViewModel(getPagedStationSuggestions, startShift)
     }
@@ -68,7 +70,7 @@ class AutonomousViewModelTest : FunSpec({
     test("submit valid input emits ShiftStarted when startShift succeeds") {
         runTest {
             fillValidForm()
-            coEvery { startShift(any(), any()) } returns true
+            coEvery { startShift(any(), any()) } returns StartShiftResult.Started
 
             vm.events.test {
                 vm.submit()
@@ -79,16 +81,34 @@ class AutonomousViewModelTest : FunSpec({
         }
     }
 
-    test("submit valid input emits Info when startShift returns false") {
+    test("submit valid input emits Info when active shift already exists") {
         runTest {
             fillValidForm()
-            coEvery { startShift(any(), any()) } returns false
+            coEvery {
+                startShift(any(), any())
+            } returns StartShiftResult.ActiveShiftAlreadyExists
 
             vm.events.test {
                 vm.submit()
                 advanceUntilIdle()
                 val event = awaitItem()
-                event shouldBe AutonomousViewModel.Event.Info("Уже есть активная смена")
+                event shouldBe AutonomousViewModel.Event.Info(R.string.active_shift_already_exists)
+            }
+        }
+    }
+
+    test("submit valid input emits Info when trip was already registered") {
+        runTest {
+            fillValidForm()
+            coEvery {
+                startShift(any(), any())
+            } returns StartShiftResult.TripAlreadyRegistered
+
+            vm.events.test {
+                vm.submit()
+                advanceUntilIdle()
+                val event = awaitItem()
+                event shouldBe AutonomousViewModel.Event.Info(R.string.trip_already_registered)
             }
         }
     }

--- a/app/src/test/java/com/chaikasoft/app/ui/viewmodels/TripViewModelTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/viewmodels/TripViewModelTest.kt
@@ -2,12 +2,16 @@ package com.chaikasoft.app.ui.viewmodels
 
 import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.common.AppError
+import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.sealed.SearchTripsResult
 import com.chaikasoft.app.domain.sealed.SendReportResult
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.CompleteShiftAndSendUseCase
+import com.chaikasoft.app.domain.usecases.DeleteActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.GetActiveShiftUseCase
 import com.chaikasoft.app.domain.usecases.GetPagedStationSuggestionsUseCase
 import com.chaikasoft.app.domain.usecases.GetShiftHistoryUseCase
+import com.chaikasoft.app.domain.usecases.HasAnyPackageItemsOnceUseCase
 import com.chaikasoft.app.domain.usecases.SearchTripsByStationsUseCase
 import com.chaikasoft.app.domain.usecases.SendShiftReportUseCase
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
@@ -21,8 +25,10 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -39,8 +45,11 @@ class TripViewModelTest : FunSpec({
     lateinit var startShift: StartShiftUseCase
     lateinit var getActiveShift: GetActiveShiftUseCase
     lateinit var completeShift: CompleteShiftAndSendUseCase
+    lateinit var deleteActiveShift: DeleteActiveShiftUseCase
+    lateinit var hasAnyPackageItems: HasAnyPackageItemsOnceUseCase
     lateinit var getShiftHistory: GetShiftHistoryUseCase
     lateinit var sendShiftReport: SendShiftReportUseCase
+    lateinit var activeShift: MutableStateFlow<ConductorTripShiftDomain?>
     lateinit var vm: TripViewModel
 
     beforeTest {
@@ -51,14 +60,19 @@ class TripViewModelTest : FunSpec({
         startShift = mockk()
         getActiveShift = mockk()
         completeShift = mockk()
+        deleteActiveShift = mockk()
+        hasAnyPackageItems = mockk()
         getShiftHistory = mockk()
         sendShiftReport = mockk()
+        activeShift = MutableStateFlow(null)
 
         every { getStations(any(), any()) } returns emptyFlow()
         coEvery { searchTrips(any(), any(), any()) } returns SearchTripsResult.Success(emptyList())
-        coEvery { startShift(any(), any()) } returns true
-        every { getActiveShift() } returns flowOf(null)
+        coEvery { startShift(any(), any()) } returns StartShiftResult.Started
+        every { getActiveShift() } returns activeShift
         coEvery { completeShift(any()) } returns SendReportResult.Success
+        coEvery { deleteActiveShift(any(), any()) } returns Unit
+        coEvery { hasAnyPackageItems() } returns false
         every { getShiftHistory() } returns flowOf(emptyList())
         coEvery { sendShiftReport(any()) } returns SendReportResult.Success
 
@@ -68,6 +82,8 @@ class TripViewModelTest : FunSpec({
             startShift,
             getActiveShift,
             completeShift,
+            deleteActiveShift,
+            hasAnyPackageItems,
             getShiftHistory,
             sendShiftReport
         )
@@ -100,7 +116,64 @@ class TripViewModelTest : FunSpec({
 
             callbackCalled shouldBe true
             coVerify(exactly = 1) { startShift(selectedTrip, any()) }
-            vm.selectedTripRecord.value shouldBe null
+            vm.selectedTripForCreation.value shouldBe null
+            vm.activeTripRecord.value shouldBe null
+        }
+    }
+
+    test("confirmCarriageInput navigates to existing active shift when start reports conflict") {
+        runTest {
+            val existingTrip = trip(uuid = "already-active")
+            activeShift.value = shift(trip = existingTrip)
+            coEvery {
+                startShift(any(), any())
+            } returns StartShiftResult.ActiveShiftAlreadyExists
+            vm.selectTrip(trip(uuid = "new-selection"))
+            vm.onCarriageNumberChanged("05")
+            var callbackCalled = false
+
+            vm.confirmCarriageInput { callbackCalled = true }
+            advanceUntilIdle()
+
+            callbackCalled shouldBe true
+            vm.selectedTripForCreation.value shouldBe null
+            vm.activeTripRecord.value shouldBe existingTrip
+        }
+    }
+
+    test("confirmCarriageInput keeps form open when trip was already registered") {
+        runTest {
+            val selectedTrip = trip(uuid = "already-registered")
+            coEvery { startShift(any(), any()) } returns StartShiftResult.TripAlreadyRegistered
+            vm.selectTrip(selectedTrip)
+            vm.onCarriageNumberChanged("05")
+            var callbackCalled = false
+
+            vm.confirmCarriageInput { callbackCalled = true }
+            advanceUntilIdle()
+
+            callbackCalled shouldBe false
+            vm.selectedTripForCreation.value shouldBe selectedTrip
+            vm.carriageNumber.value shouldBe "5"
+            vm.startShiftErrorMessageRes.value shouldBe R.string.trip_already_registered
+        }
+    }
+
+    test("confirmCarriageInput keeps creation state when start throws") {
+        runTest {
+            val selectedTrip = trip(uuid = "u-1")
+            coEvery { startShift(any(), any()) } throws IllegalArgumentException("invalid shift")
+            vm.selectTrip(selectedTrip)
+            vm.onCarriageNumberChanged("05")
+            var callbackCalled = false
+
+            vm.confirmCarriageInput { callbackCalled = true }
+            advanceUntilIdle()
+
+            callbackCalled shouldBe false
+            vm.selectedTripForCreation.value shouldBe selectedTrip
+            vm.activeTripRecord.value shouldBe null
+            vm.startShiftErrorMessageRes.value shouldBe R.string.start_shift_failed
         }
     }
 
@@ -149,7 +222,7 @@ class TripViewModelTest : FunSpec({
 
     test("finishCurrentTrip maps SendReportResult to dialog message") {
         runTest {
-            vm.selectTrip(trip(uuid = "u-finish"))
+            activeShift.value = shift(trip = trip(uuid = "u-finish"))
             coEvery { completeShift("u-finish") } returns SendReportResult.AlreadySent
 
             vm.finishCurrentTrip()
@@ -159,24 +232,80 @@ class TripViewModelTest : FunSpec({
         }
     }
 
-    test("checkActiveShift updates selected trip and shift status") {
+    test("active trip follows Room flow without manual refresh") {
         runTest {
-            val activeShift = shift(trip = trip(uuid = "active"))
-            every { getActiveShift() } returns flowOf(activeShift)
+            vm.activeTripRecord.value shouldBe null
 
-            vm = TripViewModel(
-                searchTrips,
-                getStations,
-                startShift,
-                getActiveShift,
-                completeShift,
-                getShiftHistory,
-                sendShiftReport
-            )
-            vm.checkActiveShift()
+            activeShift.value = shift(trip = trip(uuid = "active"))
+            vm.activeTripRecord.value?.uuid shouldBe "active"
+
+            activeShift.value = null
+            vm.activeTripRecord.value shouldBe null
+        }
+    }
+
+    test("empty active shift does not clear trip selected for creation") {
+        runTest {
+            val selectedTrip = trip(uuid = "selected")
+
+            vm.selectTrip(selectedTrip)
+
+            vm.selectedTripForCreation.value shouldBe selectedTrip
+            vm.activeTripRecord.value shouldBe null
+        }
+    }
+
+    test("finishCurrentTrip ignores repeated click and keeps card until Room emits null") {
+        runTest {
+            val finishResult = CompletableDeferred<SendReportResult>()
+            activeShift.value = shift(trip = trip(uuid = "u-finish"))
+            coEvery { completeShift("u-finish") } coAnswers { finishResult.await() }
+
+            vm.finishCurrentTrip()
+            vm.finishCurrentTrip()
+
+            vm.isFinishingTrip.value shouldBe true
+            vm.activeTripRecord.value?.uuid shouldBe "u-finish"
+            coVerify(exactly = 1) { completeShift("u-finish") }
+
+            activeShift.value = null
+            finishResult.complete(SendReportResult.Success)
             advanceUntilIdle()
 
-            vm.selectedTripRecord.value?.uuid shouldBe "active"
+            vm.isFinishingTrip.value shouldBe false
+            vm.activeTripRecord.value shouldBe null
+        }
+    }
+
+    test("delete request is ignored while trip is finishing") {
+        runTest {
+            val finishResult = CompletableDeferred<SendReportResult>()
+            activeShift.value = shift(trip = trip(uuid = "u-finish"))
+            coEvery { completeShift("u-finish") } coAnswers { finishResult.await() }
+
+            vm.finishCurrentTrip()
+            vm.requestDeleteCurrentTrip()
+
+            vm.deleteTripDialog.value shouldBe null
+            coVerify(exactly = 0) { hasAnyPackageItems() }
+
+            finishResult.complete(SendReportResult.Success)
+            advanceUntilIdle()
+        }
+    }
+
+    test("finish request is ignored while delete dialog is open") {
+        runTest {
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } returns true
+
+            vm.requestDeleteCurrentTrip()
+            advanceUntilIdle()
+            vm.finishCurrentTrip()
+
+            vm.deleteTripDialog.value?.hasPackageItems shouldBe true
+            vm.isFinishingTrip.value shouldBe false
+            coVerify(exactly = 0) { completeShift(any()) }
         }
     }
 
@@ -218,6 +347,8 @@ class TripViewModelTest : FunSpec({
                 startShift,
                 getActiveShift,
                 completeShift,
+                deleteActiveShift,
+                hasAnyPackageItems,
                 getShiftHistory,
                 sendShiftReport
             )
@@ -244,6 +375,92 @@ class TripViewModelTest : FunSpec({
 
             vm.dismissRetryResult()
             vm.retryResult.value shouldBe null
+        }
+    }
+
+    test("delete dialog shows package and preserves it by default") {
+        runTest {
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } returns true
+
+            vm.requestDeleteCurrentTrip()
+            advanceUntilIdle()
+
+            vm.deleteTripDialog.value?.hasPackageItems shouldBe true
+            vm.deleteTripDialog.value?.preservePackage shouldBe true
+        }
+    }
+
+    test("delete dialog can be dismissed while package inspection is pending") {
+        runTest {
+            val packageInspection = CompletableDeferred<Boolean>()
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } coAnswers { packageInspection.await() }
+
+            vm.requestDeleteCurrentTrip()
+
+            vm.deleteTripDialog.value?.hasPackageItems shouldBe null
+            vm.deleteTripDialog.value?.isDeleting shouldBe false
+
+            vm.dismissDeleteTripDialog()
+            packageInspection.complete(true)
+            advanceUntilIdle()
+
+            vm.deleteTripDialog.value shouldBe null
+        }
+    }
+
+    test("delete current trip clears operations for empty package and resets selected trip") {
+        runTest {
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } returns false
+            coEvery {
+                deleteActiveShift("u-delete", preservePackage = false)
+            } coAnswers {
+                activeShift.value = null
+            }
+
+            vm.requestDeleteCurrentTrip()
+            advanceUntilIdle()
+            vm.confirmDeleteCurrentTrip()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { deleteActiveShift("u-delete", preservePackage = false) }
+            vm.activeTripRecord.value shouldBe null
+            vm.deleteTripDialog.value shouldBe null
+        }
+    }
+
+    test("delete current trip clears operations when package preservation is disabled") {
+        runTest {
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } returns true
+
+            vm.requestDeleteCurrentTrip()
+            advanceUntilIdle()
+            vm.onPreservePackageChanged(false)
+            vm.confirmDeleteCurrentTrip()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { deleteActiveShift("u-delete", preservePackage = false) }
+        }
+    }
+
+    test("delete failure keeps dialog open with error") {
+        runTest {
+            activeShift.value = shift(trip = trip(uuid = "u-delete"))
+            coEvery { hasAnyPackageItems() } returns true
+            coEvery {
+                deleteActiveShift("u-delete", preservePackage = true)
+            } throws IllegalStateException("delete failed")
+
+            vm.requestDeleteCurrentTrip()
+            advanceUntilIdle()
+            vm.confirmDeleteCurrentTrip()
+            advanceUntilIdle()
+
+            vm.activeTripRecord.value?.uuid shouldBe "u-delete"
+            vm.deleteTripDialog.value?.errorMessageRes shouldBe R.string.trip_delete_failure
         }
     }
 })

--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.moshi:moshi:1.13.0")
 
     implementation("androidx.test:core:1.6.1")
     implementation("androidx.test:runner:1.6.2")

--- a/e2e-tests/src/main/kotlin/com/chaikasoft/app/e2e/tests/HermeticSmokeE2ETest.kt
+++ b/e2e-tests/src/main/kotlin/com/chaikasoft/app/e2e/tests/HermeticSmokeE2ETest.kt
@@ -1,6 +1,7 @@
 ﻿package com.chaikasoft.app.e2e.tests
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -11,6 +12,8 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.filters.LargeTest
 import com.chaikasoft.app.R
 import com.chaikasoft.app.data.room.AppDatabase
+import com.chaikasoft.app.data.room.entities.CartItem
+import com.chaikasoft.app.data.room.entities.CartOperation
 import com.chaikasoft.app.data.room.repo.RoomConductorRepositoryInterface
 import com.chaikasoft.app.data.room.repo.RoomConductorTripShiftRepositoryInterface
 import com.chaikasoft.app.data.room.repo.RoomProductInfoRepositoryInterface
@@ -24,6 +27,7 @@ import com.chaikasoft.app.domain.models.report.TripIdReport
 import com.chaikasoft.app.domain.models.trip.ConductorTripShiftDomain
 import com.chaikasoft.app.domain.models.trip.TripDomain
 import com.chaikasoft.app.domain.models.trip.TripShiftStatusDomain
+import com.chaikasoft.app.domain.sealed.StartShiftResult
 import com.chaikasoft.app.domain.usecases.StartShiftUseCase
 import com.chaikasoft.app.e2e.fixtures.E2EFixtures
 import com.chaikasoft.app.e2e.rules.FailureDiagnosticsRule
@@ -33,6 +37,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.first
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -152,6 +157,52 @@ class HermeticSmokeE2ETest {
 
         openProductSectionWithActiveShift()
         waitForAnyTag("productEntryFillPackageButton", "productCartFab")
+    }
+
+    @Test
+    fun activeTrip_canBeDeletedWhilePreservingPackage() {
+        waitForTag("tripMainScreen")
+        startActiveShift()
+        seedPackageOperation()
+
+        val deleteButtonTag = "currentTripDelete_${E2EFixtures.trips.first().uuid}"
+        waitForTag(deleteButtonTag)
+        composeRule.onNodeWithTag(deleteButtonTag, useUnmergedTree = true).performClick()
+
+        waitForTag("deleteTripBottomSheet")
+        waitForTag("deleteTripPreservePackageCheckbox")
+        composeRule.onNodeWithTag("deleteTripPreservePackageCheckbox", useUnmergedTree = true)
+            .assertIsOn()
+        composeRule.onNodeWithTag("deleteTripConfirmButton").performClick()
+
+        waitForTag("newTripButton")
+        runBlocking {
+            check(db.conductorTripShiftDao().getByUuid(E2EFixtures.trips.first().uuid) == null)
+            check(db.cartOperationDao().getAllOperations().first().size == 1)
+            check(db.cartItemDao().getAllCartItems().first().size == 1)
+        }
+    }
+
+    @Test
+    fun activeTrip_finishingMovesCardToHistory() {
+        waitForTag("tripMainScreen")
+        startActiveShift()
+
+        waitForTag("currentTripFinishButton")
+        composeRule.onNodeWithTag("currentTripFinishButton").performClick()
+
+        waitForTag("finishTripConfirmBottomSheet")
+        composeRule.onNodeWithTag("finishTripConfirmCheckbox", useUnmergedTree = true)
+            .performClick()
+        composeRule.onNodeWithTag("finishTripConfirmButton", useUnmergedTree = true)
+            .performClick()
+
+        waitForTag("newTripButton")
+        waitForTag("historyRecordCard_${E2EFixtures.trips.first().uuid}")
+        runBlocking {
+            val savedShift = db.conductorTripShiftDao().getByUuid(E2EFixtures.trips.first().uuid)
+            check(savedShift?.status == TripShiftStatusDomain.SENT.code)
+        }
     }
 
     @Test
@@ -306,15 +357,43 @@ class HermeticSmokeE2ETest {
         }
     }
 
-    private fun startActiveShift() = runBlocking {
-        val started = startShiftUseCase(
-            trip = E2EFixtures.trips.first(),
-            activeCarriage = E2EFixtures.activeCarriage,
-        )
-        val activeShift = shiftRepository.getActiveShift()
-        check(started || activeShift != null) {
-            "Expected an active shift to exist before opening protected sections"
+    private fun startActiveShift() {
+        val result = runBlocking {
+            startShiftUseCase(
+                trip = E2EFixtures.trips.first(),
+                activeCarriage = E2EFixtures.activeCarriage,
+            )
         }
+        val activeShift = runBlocking { shiftRepository.getActiveShift() }
+
+        check(result == StartShiftResult.Started || activeShift != null) {
+            "Expected an active shift to exist before opening protected sections, got $result"
+        }
+
+        composeRule.waitForIdle()
+        waitForTag("currentTripFinishButton")
+    }
+
+    private fun seedPackageOperation() = runBlocking {
+        val conductor = db.conductorDao()
+            .getConductorByEmployeeID(E2EFixtures.conductor.employeeID)
+            ?: error("Expected authenticated conductor")
+        val product = db.productInfoDao().getProductById(E2EFixtures.products.first().id)
+            ?: error("Expected refreshed product")
+        val operationId = db.cartOperationDao().insertOperation(
+            CartOperation(
+                operationType = OperationTypeDomain.ADD.ordinal,
+                operationTime = "2026-04-11T08:30:00+03:00",
+                conductorId = conductor.id
+            )
+        ).toInt()
+        db.cartItemDao().insertCartItem(
+            CartItem(
+                cartOperationId = operationId,
+                productId = product.id,
+                impact = 2
+            )
+        )
         composeRule.waitForIdle()
     }
 
@@ -335,7 +414,9 @@ class HermeticSmokeE2ETest {
                 status = TripShiftStatusDomain.ACTIVE
             )
         )
-        check(shiftCreated) { "Expected historical shift seed to create a fresh active shift" }
+        check(shiftCreated == StartShiftResult.Started) {
+            "Expected historical shift seed to create a fresh active shift"
+        }
 
         shiftRepository.updateStatusAndReport(
             uuid = HISTORICAL_SHIFT_UUID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Удаление текущей поездки через кнопку на карточке с подтверждающим bottom sheet и опцией «сохранить пакет»/«очистить операции».

* **Behavior**
  * Старт смены возвращает типизированный результат (Started / ActiveShiftAlreadyExists / TripAlreadyRegistered); UI и сценарии обработки обновлены.

* **UI**
  * Обновлён макет текущей и исторических карточек, добавлена иконка удаления, блокировка кнопок во время операций и тест‑теги для ключевых элементов; размеры карточек скорректированы.

* **Localization**
  * Добавлены строки для диалога удаления и сообщений о результатах старта смены.

* **Tests**
  * Расширены модульные, транзакционные и e2e‑тесты для удаления поездки, транзакционных сценариев и старта/завершения смены.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->