### PR TITLE
CHK-238 Conductor from ZITADEL field rework

### DIFF
--- a/app/src/androidTest/java/com/example/chaika/apiUseCases/FetchConductorByTokenUseCaseIntegrationTest.kt
+++ b/app/src/androidTest/java/com/example/chaika/apiUseCases/FetchConductorByTokenUseCaseIntegrationTest.kt
@@ -48,11 +48,11 @@ class FetchConductorByTokenUseCaseIntegrationTest {
         // Подготавливаем корректный JSON-ответ, который соответствует ConductorDto
         val responseBody = """
             {
-              "name": "John",
               "family_name": "Doe",
               "given_name": "John",
-              "nickname": "12345",
-              "image": "https://example.com/johndoe.jpg"
+              "middle_name": "Michael",
+              "preferred_username": "12345",
+              "picture": "https://example.com/johndoe.jpg"
             }
         """.trimIndent()
         TestServerHolder.testMockServer.server.enqueue(
@@ -66,7 +66,7 @@ class FetchConductorByTokenUseCaseIntegrationTest {
         val result: ConductorDomain = fetchConductorByTokenUseCase("dummyToken")
         assertEquals("John", result.name)
         assertEquals("Doe", result.familyName)
-        assertEquals("John", result.givenName)
+        assertEquals("Michael", result.givenName)
         assertEquals("12345", result.employeeID)
         assertEquals("https://example.com/johndoe.jpg", result.image)
     }

--- a/app/src/main/java/com/chaikasoft/app/data/datasource/dto/ConductorDto.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/datasource/dto/ConductorDto.kt
@@ -3,14 +3,14 @@ package com.chaikasoft.app.data.datasource.dto
 import com.google.gson.annotations.SerializedName
 
 data class ConductorDto(
-    @SerializedName("name")
-    val name: String,
+    @SerializedName("given_name")
+    val firstName: String,
     @SerializedName("family_name")
     val familyName: String,
-    @SerializedName("given_name")
-    val givenName: String,
-    @SerializedName("nickname")
-    val nickname: String, // с сервера приходит nickname
-    @SerializedName("image")
-    val image: String? = null
+    @SerializedName("middle_name")
+    val middleName: String? = null,
+    @SerializedName("preferred_username")
+    val preferredUsername: String,
+    @SerializedName(value = "picture", alternate = ["image", "avatarUrl", "avatar_url"])
+    val picture: String? = null
 )

--- a/app/src/main/java/com/chaikasoft/app/data/datasource/mappers/ConductorDtoMapper.kt
+++ b/app/src/main/java/com/chaikasoft/app/data/datasource/mappers/ConductorDtoMapper.kt
@@ -5,14 +5,14 @@ import com.chaikasoft.app.domain.models.ConductorDomain
 
 /**
  * Преобразует ConductorDto (данные с сервера) в доменную модель ConductorDomain.
- * Здесь поле nickname маппится на employeeID, а id остаётся неустановленным,
- * поскольку сервер не передаёт его.
+ * Поля берутся из смысловых OIDC claims: given_name, family_name, middle_name,
+ * preferred_username и picture.
  */
 fun ConductorDto.toDomain(): ConductorDomain = ConductorDomain(
     id = 0, // или можно сделать id: Int? и оставить null
-    name = this.name,
+    name = this.firstName,
     familyName = this.familyName,
-    givenName = this.givenName,
-    employeeID = this.nickname,
-    image = this.image?.trim().orEmpty()
+    givenName = this.middleName?.trim().orEmpty(),
+    employeeID = this.preferredUsername,
+    image = this.picture?.trim().orEmpty()
 )

--- a/app/src/test/java/com/chaikasoft/app/data/datasource/mappers/ConductorDtoMapperTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/data/datasource/mappers/ConductorDtoMapperTest.kt
@@ -10,17 +10,17 @@ class ConductorDtoMapperTest : FunSpec({
      * Техника тест-дизайна: #1 Классы эквивалентности
      *
      * Описание:
-     *   - Вход: DTO проводника с заполненным image и nickname.
-     *   - Ожидаемое поведение: nickname маппится в employeeID, image сохраняется как есть.
+     *   - Вход: DTO проводника с заполненным picture и preferredUsername.
+     *   - Ожидаемое поведение: OIDC claims маппятся в поля ConductorDomain по смыслу.
      *   - Цель: зафиксировать основной контракт ConductorDto -> ConductorDomain без подмены изображения.
      */
-    test("maps nickname to employeeID and keeps explicit image") {
+    test("maps oidc claims to conductor domain") {
         val dto = ConductorDto(
-            name = "Ivan",
+            firstName = "Ivan",
             familyName = "Petrov",
-            givenName = "Ivanovich",
-            nickname = "EMP-001",
-            image = "https://example.com/avatar.png",
+            middleName = "Ivanovich",
+            preferredUsername = "EMP-001",
+            picture = "https://example.com/avatar.png",
         )
 
         val domain = dto.toDomain()
@@ -43,11 +43,11 @@ class ConductorDtoMapperTest : FunSpec({
      */
     test("maps missing dto image to empty string") {
         val dto = ConductorDto(
-            name = "Ivan",
+            firstName = "Ivan",
             familyName = "Petrov",
-            givenName = "Ivanovich",
-            nickname = "EMP-001",
-            image = null,
+            middleName = "Ivanovich",
+            preferredUsername = "EMP-001",
+            picture = null,
         )
 
         val domain = dto.toDomain()

--- a/app/src/test/java/com/chaikasoft/app/data/datasource/repo/IAMApiServiceRepositoryTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/data/datasource/repo/IAMApiServiceRepositoryTest.kt
@@ -34,11 +34,11 @@ class IAMApiServiceRepositoryTest : FunSpec({
     test("fetchUserInfo success returns mapped ConductorDomain and sends Bearer token") {
         runTest {
             val dto = ConductorDto(
-                name = "Ivan",
+                firstName = "Ivan",
                 familyName = "Petrov",
-                givenName = "Ivanovich",
-                nickname = "EMP-1",
-                image = "https://example.com/avatar.png",
+                middleName = "Ivanovich",
+                preferredUsername = "EMP-1",
+                picture = "https://example.com/avatar.png",
             )
             coEvery { api.getUserInfo("Bearer token-123") } returns dto
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Обновления

* **Баг-фиксы**
  * Исправлена обработка данных профиля проводника при получении информации из системы аутентификации (имена и фотографии теперь считываются корректно).

* **Тесты**
  * Обновлены интеграционные и модульные тесты для проверки корректного отображения профиля.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->