### PR TITLE
CHK-264 ProductReplanishView & TemplateEditView UX fix

### DIFF
--- a/app/src/main/java/com/chaikasoft/app/ui/components/product/CartProductItem.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/product/CartProductItem.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.chaikasoft.app.R
@@ -120,7 +119,7 @@ fun CartProductItem(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 8.dp)
+                    .padding(top = ProductDimens.PaddingM)
                     .constrainAs(divBottom) {
                         top.linkTo(imageRef.bottom)
                         start.linkTo(parent.start)
@@ -145,6 +144,7 @@ private fun CartProductActionsRow(
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .padding(end = ProductDimens.PaddingM)
             .height(ProductDimens.CartProductItem.QuantitySelectorHeight)
     ) {
         // Цена слева
@@ -184,7 +184,7 @@ private fun CartProductActionsRow(
                         height = ProductDimens.CartProductItem.QuantitySelectorHeight
                     ),
                 shape = CircleShape,
-                contentPadding = PaddingValues(0.dp),
+                contentPadding = PaddingValues(),
                 colors = ButtonDefaults.buttonColors(
                     contentColor = MaterialTheme.colorScheme.primary
                 ),

--- a/app/src/main/java/com/chaikasoft/app/ui/components/product/ReplenishProductItem.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/components/product/ReplenishProductItem.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.chaikasoft.app.R
@@ -117,7 +116,7 @@ fun ReplenishProductItem(
             HorizontalDivider(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 8.dp)
+                    .padding(top = ProductDimens.PaddingM)
                     .constrainAs(divBottom) {
                         top.linkTo(imageRef.bottom)
                         start.linkTo(parent.start)
@@ -142,6 +141,7 @@ private fun StockQuantityRow(
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .padding(end = ProductDimens.PaddingM)
             .height(ProductDimens.CartProductItem.QuantitySelectorHeight)
     ) {
         // Левый блок: остаток
@@ -151,7 +151,7 @@ private fun StockQuantityRow(
         ) {
             val qtyText = if (quantityToShow >= 0) quantityToShow.toString() else "—"
             Text(
-                text = "Остаток: $qtyText",
+                text = stringResource(R.string.replenish_product_stock, qtyText),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.Bold,
                 color = if (quantityToShow <= 0) {
@@ -206,7 +206,7 @@ private fun StockQuantityRow(
                         height = ProductDimens.CartProductItem.QuantitySelectorHeight
                     ),
                 shape = CircleShape,
-                contentPadding = PaddingValues(0.dp),
+                contentPadding = PaddingValues(),
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary, // яркая красная пилюля
                     contentColor = Color.White

--- a/app/src/main/java/com/chaikasoft/app/ui/dto/ReplenishProductUiModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/dto/ReplenishProductUiModel.kt
@@ -1,0 +1,3 @@
+package com.chaikasoft.app.ui.dto
+
+data class ReplenishProductUiModel(val product: Product, val packageQuantity: Int)

--- a/app/src/main/java/com/chaikasoft/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/navigation/NavGraph.kt
@@ -348,12 +348,10 @@ fun NavGraph(
                 val replenishViewModel = hiltViewModel<ReplenishViewModel>(parentEntry)
                 val replenishItemsViewModel = hiltViewModel<ReplenishItemsViewModel>(parentEntry)
                 val conductorViewModel = hiltViewModel<ConductorViewModel>(parentEntry)
-                val packageViewModel = hiltViewModel<PackageViewModel>(parentEntry)
                 ProductReplenishView(
                     replenishViewModel = replenishViewModel,
                     conductorViewModel = conductorViewModel,
                     replenishItemsViewModel = replenishItemsViewModel,
-                    packageViewModel = packageViewModel,
                     navController = navController
                 )
             }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/product/ProductReplenishView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/product/ProductReplenishView.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -27,8 +28,10 @@ import com.chaikasoft.app.R
 import com.chaikasoft.app.ui.components.product.ReplenishProductItem
 import com.chaikasoft.app.ui.components.template.ButtonSurface
 import com.chaikasoft.app.ui.components.template.CheckDialog
+import com.chaikasoft.app.ui.dto.Product
 import com.chaikasoft.app.ui.mappers.toCartItemDomain
 import com.chaikasoft.app.ui.navigation.Routes
+import com.chaikasoft.app.ui.theme.ChaikaTheme
 import com.chaikasoft.app.ui.viewmodels.ConductorViewModel
 import com.chaikasoft.app.ui.viewmodels.PackageViewModel
 import com.chaikasoft.app.ui.viewmodels.ReplenishItemsViewModel
@@ -57,63 +60,17 @@ fun ProductReplenishView(
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { innerPadding ->
-        Box(modifier = Modifier.fillMaxSize()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
-            ) {
-                Box(modifier = Modifier.weight(1f)) {
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(1),
-                        modifier = Modifier
-                            .testTag("productListGrid"),
-                        contentPadding = PaddingValues(
-                            bottom = 72.dp
-                        )
-                    ) {
-                        items(
-                            count = displayProducts.value.size,
-                            key = { index -> displayProducts.value[index].id }
-                        ) { index ->
-                            displayProducts.value[index].let { product ->
-                                ReplenishProductItem(
-                                    modifier = Modifier.testTag("productCard"),
-                                    product = product,
-                                    onAddToCart = {
-                                        replenishViewModel.onAdd(product.toCartItemDomain())
-                                    },
-                                    onQuantityIncrease = {
-                                        replenishViewModel.onQuantityChange(
-                                            product.id,
-                                            product.quantity + 1
-                                        )
-                                    },
-                                    onQuantityDecrease = {
-                                        replenishViewModel.onQuantityChange(
-                                            product.id,
-                                            product.quantity - 1
-                                        )
-                                    },
-                                    onRemove = {
-                                        replenishViewModel.onRemove(product.id)
-                                    },
-                                    packageQuantity =
-                                    productQuantities[product.id] ?: product.quantity
-                                )
-                            }
-                        }
-                    }
-                }
-
-                ButtonSurface(
-                    buttonText = "ДАЛЕЕ",
-                    onClick = { showDialog = true },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                )
-            }
-        }
+        ProductReplenishContent(
+            products = displayProducts.value,
+            productQuantities = productQuantities,
+            onAddToCart = { product ->
+                replenishViewModel.onAdd(product.toCartItemDomain())
+            },
+            onQuantityChange = replenishViewModel::onQuantityChange,
+            onRemove = replenishViewModel::onRemove,
+            onNextClick = { showDialog = true },
+            modifier = Modifier.padding(innerPadding)
+        )
 
         if (showDialog) {
             CheckDialog(
@@ -138,5 +95,90 @@ fun ProductReplenishView(
                 }
             )
         }
+    }
+}
+
+@Composable
+private fun ProductReplenishContent(
+    products: List<Product>,
+    productQuantities: Map<Int, Int>,
+    onAddToCart: (Product) -> Unit,
+    onQuantityChange: (productId: Int, quantity: Int) -> Unit,
+    onRemove: (productId: Int) -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        Box(modifier = Modifier.weight(1f)) {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(1),
+                modifier = Modifier.testTag("productListGrid"),
+                contentPadding = PaddingValues(bottom = 72.dp)
+            ) {
+                items(
+                    count = products.size,
+                    key = { index -> products[index].id }
+                ) { index ->
+                    val product = products[index]
+                    ReplenishProductItem(
+                        modifier = Modifier.testTag("productCard"),
+                        product = product,
+                        onAddToCart = { onAddToCart(product) },
+                        onQuantityIncrease = {
+                            onQuantityChange(product.id, product.quantity + 1)
+                        },
+                        onQuantityDecrease = {
+                            onQuantityChange(product.id, product.quantity - 1)
+                        },
+                        onRemove = { onRemove(product.id) },
+                        packageQuantity = productQuantities[product.id] ?: product.quantity
+                    )
+                }
+            }
+        }
+
+        ButtonSurface(
+            buttonText = "ДАЛЕЕ",
+            onClick = onNextClick,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640)
+@Composable
+private fun ProductReplenishContentPreview() {
+    val products = listOf(
+        Product(
+            id = 1,
+            name = "Яблочный сок",
+            description = "Свежий яблочный сок",
+            image = "",
+            price = 120,
+            isInCart = true,
+            quantity = 2
+        ),
+        Product(
+            id = 2,
+            name = "Чёрный чай",
+            description = "Ароматный чёрный чай",
+            image = "",
+            price = 85,
+            isInCart = false,
+            quantity = 0
+        )
+    )
+
+    ChaikaTheme {
+        ProductReplenishContent(
+            products = products,
+            productQuantities = mapOf(1 to 12, 2 to 0),
+            onAddToCart = {},
+            onQuantityChange = { _, _ -> },
+            onRemove = {},
+            onNextClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/product/ProductReplenishView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/product/ProductReplenishView.kt
@@ -29,11 +29,11 @@ import com.chaikasoft.app.ui.components.product.ReplenishProductItem
 import com.chaikasoft.app.ui.components.template.ButtonSurface
 import com.chaikasoft.app.ui.components.template.CheckDialog
 import com.chaikasoft.app.ui.dto.Product
+import com.chaikasoft.app.ui.dto.ReplenishProductUiModel
 import com.chaikasoft.app.ui.mappers.toCartItemDomain
 import com.chaikasoft.app.ui.navigation.Routes
 import com.chaikasoft.app.ui.theme.ChaikaTheme
 import com.chaikasoft.app.ui.viewmodels.ConductorViewModel
-import com.chaikasoft.app.ui.viewmodels.PackageViewModel
 import com.chaikasoft.app.ui.viewmodels.ReplenishItemsViewModel
 import com.chaikasoft.app.ui.viewmodels.ReplenishViewModel
 import kotlinx.coroutines.launch
@@ -43,7 +43,6 @@ fun ProductReplenishView(
     conductorViewModel: ConductorViewModel,
     replenishViewModel: ReplenishViewModel,
     replenishItemsViewModel: ReplenishItemsViewModel,
-    packageViewModel: PackageViewModel,
     navController: NavHostController
 ) {
     val conductor = conductorViewModel.conductor.collectAsStateWithLifecycle()
@@ -53,7 +52,6 @@ fun ProductReplenishView(
     val displayProducts = remember(replenishViewModel.items) {
         replenishItemsViewModel.getDisplayProducts(replenishViewModel.items)
     }.collectAsStateWithLifecycle()
-    val productQuantities by packageViewModel.productQuantities.collectAsStateWithLifecycle()
     val checkDialogText = stringResource(id = R.string.template_check_contents)
     val errorNoConductorMsg = stringResource(id = R.string.error_no_conductor)
 
@@ -62,7 +60,6 @@ fun ProductReplenishView(
     ) { innerPadding ->
         ProductReplenishContent(
             products = displayProducts.value,
-            productQuantities = productQuantities,
             onAddToCart = { product ->
                 replenishViewModel.onAdd(product.toCartItemDomain())
             },
@@ -100,8 +97,7 @@ fun ProductReplenishView(
 
 @Composable
 private fun ProductReplenishContent(
-    products: List<Product>,
-    productQuantities: Map<Int, Int>,
+    products: List<ReplenishProductUiModel>,
     onAddToCart: (Product) -> Unit,
     onQuantityChange: (productId: Int, quantity: Int) -> Unit,
     onRemove: (productId: Int) -> Unit,
@@ -119,9 +115,10 @@ private fun ProductReplenishContent(
             ) {
                 items(
                     count = products.size,
-                    key = { index -> products[index].id }
+                    key = { index -> products[index].product.id }
                 ) { index ->
-                    val product = products[index]
+                    val item = products[index]
+                    val product = item.product
                     ReplenishProductItem(
                         modifier = Modifier.testTag("productCard"),
                         product = product,
@@ -133,14 +130,14 @@ private fun ProductReplenishContent(
                             onQuantityChange(product.id, product.quantity - 1)
                         },
                         onRemove = { onRemove(product.id) },
-                        packageQuantity = productQuantities[product.id] ?: product.quantity
+                        packageQuantity = item.packageQuantity
                     )
                 }
             }
         }
 
         ButtonSurface(
-            buttonText = "ДАЛЕЕ",
+            buttonText = stringResource(R.string.action_next),
             onClick = onNextClick,
             modifier = Modifier.fillMaxWidth()
         )
@@ -151,30 +148,35 @@ private fun ProductReplenishContent(
 @Composable
 private fun ProductReplenishContentPreview() {
     val products = listOf(
-        Product(
-            id = 1,
-            name = "Яблочный сок",
-            description = "Свежий яблочный сок",
-            image = "",
-            price = 120,
-            isInCart = true,
-            quantity = 2
+        ReplenishProductUiModel(
+            product = Product(
+                id = 1,
+                name = "Яблочный сок",
+                description = "Свежий яблочный сок",
+                image = "",
+                price = 120,
+                isInCart = true,
+                quantity = 2
+            ),
+            packageQuantity = 12
         ),
-        Product(
-            id = 2,
-            name = "Чёрный чай",
-            description = "Ароматный чёрный чай",
-            image = "",
-            price = 85,
-            isInCart = false,
-            quantity = 0
+        ReplenishProductUiModel(
+            product = Product(
+                id = 2,
+                name = "Чёрный чай",
+                description = "Ароматный чёрный чай",
+                image = "",
+                price = 85,
+                isInCart = false,
+                quantity = 0
+            ),
+            packageQuantity = 0
         )
     )
 
     ChaikaTheme {
         ProductReplenishContent(
             products = products,
-            productQuantities = mapOf(1 to 12, 2 to 0),
             onAddToCart = {},
             onQuantityChange = { _, _ -> },
             onRemove = {},

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/product/TemplateEditView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/product/TemplateEditView.kt
@@ -31,12 +31,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
 import com.chaikasoft.app.domain.models.CartItemDomain
 import com.chaikasoft.app.ui.components.product.CartProductItem
 import com.chaikasoft.app.ui.components.template.ButtonSurface
@@ -45,6 +47,7 @@ import com.chaikasoft.app.ui.dto.Product
 import com.chaikasoft.app.ui.mappers.toCartItemDomain
 import com.chaikasoft.app.ui.mappers.toUiModel
 import com.chaikasoft.app.ui.navigation.Routes
+import com.chaikasoft.app.ui.theme.ChaikaTheme
 import com.chaikasoft.app.ui.theme.ProductDimens
 import com.chaikasoft.app.ui.viewmodels.ConductorViewModel
 import com.chaikasoft.app.ui.viewmodels.FillViewModel
@@ -65,35 +68,28 @@ fun TemplateEditView(
 
     Scaffold { innerPadding ->
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
+        TemplateEditContent(
+            searchQuery = searchQuery,
+            onSearchChange = productViewModel::onSearchChange,
+            onNextClick = {
+                val conductorId = conductorViewModel.conductor.value?.id
+                if (conductorId == null) {
+                    showNoConductorError = true
+                } else {
+                    navController.navigate(Routes.TEMPLATE_CONFIRM)
+                }
+            },
+            modifier = Modifier.padding(innerPadding)
         ) {
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = productViewModel::onSearchChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(4.dp),
-                placeholder = { Text("Поиск по названию") },
-                singleLine = true,
-                shape = RoundedCornerShape(ProductDimens.CornerRadiusM)
-            )
-
-            ProductScreenContent(
+            ProductPagingContent(
                 pagingItems = pagingItems,
                 cartItems = cartItems,
-                fillViewModel = fillViewModel,
-                modifier = Modifier.weight(1f),
-                onNextClick = {
-                    val conductorId = conductorViewModel.conductor.value?.id
-                    if (conductorId == null) {
-                        showNoConductorError = true
-                    } else {
-                        navController.navigate(Routes.TEMPLATE_CONFIRM)
-                    }
-                }
+                onAddToCart = { product ->
+                    fillViewModel.onAdd(product.toCartItemDomain())
+                },
+                onQuantityChange = fillViewModel::onQuantityChange,
+                onRemove = fillViewModel::onRemove,
+                modifier = Modifier.fillMaxSize()
             )
         }
 
@@ -112,42 +108,29 @@ fun TemplateEditView(
 }
 
 @Composable
-private fun ProductScreenContent(
-    pagingItems: LazyPagingItems<Product>,
-    cartItems: List<CartItemDomain>,
-    fillViewModel: FillViewModel,
+private fun TemplateEditContent(
+    searchQuery: String,
+    onSearchChange: (String) -> Unit,
     onNextClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    productContent: @Composable () -> Unit
 ) {
-    val refreshState = pagingItems.loadState.refresh
-    val itemCount = pagingItems.itemCount
+    Column(
+        modifier = modifier.fillMaxSize()
+    ) {
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = onSearchChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp),
+            placeholder = { Text("Поиск по названию") },
+            singleLine = true,
+            shape = RoundedCornerShape(ProductDimens.CornerRadiusM)
+        )
 
-    Column(modifier = modifier) {
         Box(modifier = Modifier.weight(1f)) {
-            when {
-                refreshState is LoadState.Loading && itemCount == 0 -> {
-                    LoadingState()
-                }
-
-                refreshState is LoadState.Error && itemCount == 0 -> {
-                    ErrorState(
-                        error = refreshState.error,
-                        onRetry = { pagingItems.retry() }
-                    )
-                }
-
-                refreshState is LoadState.NotLoading && itemCount == 0 -> {
-                    EmptyState()
-                }
-
-                else -> {
-                    ProductList(
-                        pagingItems = pagingItems,
-                        cartItems = cartItems,
-                        fillViewModel = fillViewModel
-                    )
-                }
-            }
+            productContent()
         }
 
         ButtonSurface(
@@ -159,10 +142,54 @@ private fun ProductScreenContent(
 }
 
 @Composable
+private fun ProductPagingContent(
+    pagingItems: LazyPagingItems<Product>,
+    cartItems: List<CartItemDomain>,
+    onAddToCart: (Product) -> Unit,
+    onQuantityChange: (productId: Int, quantity: Int) -> Unit,
+    onRemove: (productId: Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val refreshState = pagingItems.loadState.refresh
+    val itemCount = pagingItems.itemCount
+
+    Box(modifier = modifier) {
+        when {
+            refreshState is LoadState.Loading && itemCount == 0 -> {
+                LoadingState()
+            }
+
+            refreshState is LoadState.Error && itemCount == 0 -> {
+                ErrorState(
+                    error = refreshState.error,
+                    onRetry = pagingItems::retry
+                )
+            }
+
+            refreshState is LoadState.NotLoading && itemCount == 0 -> {
+                EmptyState()
+            }
+
+            else -> {
+                ProductList(
+                    pagingItems = pagingItems,
+                    cartItems = cartItems,
+                    onAddToCart = onAddToCart,
+                    onQuantityChange = onQuantityChange,
+                    onRemove = onRemove
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun ProductList(
     pagingItems: LazyPagingItems<Product>,
     cartItems: List<CartItemDomain>,
-    fillViewModel: FillViewModel,
+    onAddToCart: (Product) -> Unit,
+    onQuantityChange: (productId: Int, quantity: Int) -> Unit,
+    onRemove: (productId: Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val cartMap = remember(cartItems) {
@@ -178,9 +205,7 @@ private fun ProductList(
     ) {
         items(
             count = pagingItems.itemCount,
-            key = { index ->
-                pagingItems.peek(index)?.id ?: "placeholder_$index"
-            }
+            key = pagingItems.itemKey { product -> product.id }
         ) { index ->
             val product = pagingItems[index]
             if (product != null) {
@@ -190,24 +215,20 @@ private fun ProductList(
 
                 CartProductItem(
                     product = uiProduct,
-                    onAddToCart = {
-                        fillViewModel.onAdd(product.toCartItemDomain())
-                    },
+                    onAddToCart = { onAddToCart(product) },
                     onQuantityIncrease = {
-                        fillViewModel.onQuantityChange(
+                        onQuantityChange(
                             uiProduct.id,
                             uiProduct.quantity + 1
                         )
                     },
                     onQuantityDecrease = {
-                        fillViewModel.onQuantityChange(
+                        onQuantityChange(
                             uiProduct.id,
                             uiProduct.quantity - 1
                         )
                     },
-                    onRemove = {
-                        fillViewModel.onRemove(uiProduct.id)
-                    }
+                    onRemove = { onRemove(uiProduct.id) }
                 )
             }
         }
@@ -228,13 +249,11 @@ private fun ProductList(
                 is LoadState.Error -> {
                     ErrorItem(
                         error = appendState.error,
-                        onRetry = { pagingItems.retry() }
+                        onRetry = pagingItems::retry
                     )
                 }
 
-                is LoadState.NotLoading -> {
-                    // Ничего не показываем
-                }
+                is LoadState.NotLoading -> Unit
             }
         }
     }
@@ -322,3 +341,62 @@ private fun ErrorItem(error: Throwable, onRetry: () -> Unit, modifier: Modifier 
         }
     }
 }
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 640)
+@Composable
+private fun TemplateEditContentPreview() {
+    val products = templatePreviewProducts()
+
+    ChaikaTheme {
+        TemplateEditContent(
+            searchQuery = "",
+            onSearchChange = {},
+            onNextClick = {}
+        ) {
+            TemplateEditPreviewProductList(products = products)
+        }
+    }
+}
+
+@Composable
+private fun TemplateEditPreviewProductList(products: List<Product>, modifier: Modifier = Modifier) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(1),
+        modifier = modifier,
+        contentPadding = PaddingValues(bottom = 72.dp)
+    ) {
+        items(
+            count = products.size,
+            key = { index -> products[index].id }
+        ) { index ->
+            CartProductItem(
+                product = products[index],
+                onAddToCart = {},
+                onQuantityIncrease = {},
+                onQuantityDecrease = {},
+                onRemove = {}
+            )
+        }
+    }
+}
+
+private fun templatePreviewProducts() = listOf(
+    Product(
+        id = 1,
+        name = "Яблочный сок",
+        description = "Свежий яблочный сок",
+        image = "",
+        price = 120,
+        isInCart = true,
+        quantity = 2
+    ),
+    Product(
+        id = 2,
+        name = "Чёрный чай",
+        description = "Ароматный чёрный чай",
+        image = "",
+        price = 85,
+        isInCart = false,
+        quantity = 1
+    )
+)

--- a/app/src/main/java/com/chaikasoft/app/ui/screens/product/TemplateEditView.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/screens/product/TemplateEditView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,6 +40,7 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
+import com.chaikasoft.app.R
 import com.chaikasoft.app.domain.models.CartItemDomain
 import com.chaikasoft.app.ui.components.product.CartProductItem
 import com.chaikasoft.app.ui.components.template.ButtonSurface
@@ -124,7 +126,7 @@ private fun TemplateEditContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(4.dp),
-            placeholder = { Text("Поиск по названию") },
+            placeholder = { Text(stringResource(R.string.hint_product_search)) },
             singleLine = true,
             shape = RoundedCornerShape(ProductDimens.CornerRadiusM)
         )
@@ -134,7 +136,7 @@ private fun TemplateEditContent(
         }
 
         ButtonSurface(
-            buttonText = "ДАЛЕЕ",
+            buttonText = stringResource(R.string.action_next),
             onClick = onNextClick,
             modifier = Modifier.fillMaxWidth()
         )

--- a/app/src/main/java/com/chaikasoft/app/ui/viewmodels/ReplenishItemsViewModel.kt
+++ b/app/src/main/java/com/chaikasoft/app/ui/viewmodels/ReplenishItemsViewModel.kt
@@ -6,6 +6,7 @@ import com.chaikasoft.app.domain.models.CartItemDomain
 import com.chaikasoft.app.domain.models.PackageItemDomain
 import com.chaikasoft.app.domain.usecases.GetPackageItemUseCase
 import com.chaikasoft.app.ui.dto.Product
+import com.chaikasoft.app.ui.dto.ReplenishProductUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
@@ -27,20 +28,20 @@ class ReplenishItemsViewModel @Inject constructor(
      * Создает поток продуктов для отображения, объединяя товары из пакета с данными корзины.
      * @param cartItems Поток элементов корзины, передаваемый из уровня экрана
      */
-    fun getDisplayProducts(cartItems: StateFlow<List<CartItemDomain>>): StateFlow<List<Product>> =
-        combine(
-            packageItems,
-            cartItems
-        ) { packageList, cartList ->
-            // Создаем мапу количеств из корзины по ID продукта
-            val cartQuantities = cartList.associate { it.product.id to it.quantity }
+    fun getDisplayProducts(
+        cartItems: StateFlow<List<CartItemDomain>>
+    ): StateFlow<List<ReplenishProductUiModel>> = combine(
+        packageItems,
+        cartItems
+    ) { packageList, cartList ->
+        val cartQuantities = cartList.associate { it.product.id to it.quantity }
 
-            // Преобразуем packageItems в Product с учетом количеств из корзины
-            packageList.map { packageItem ->
-                val cartQuantity = cartQuantities[packageItem.productInfoDomain.id] ?: 0
-                val isInCart = cartQuantity > 0
+        packageList.map { packageItem ->
+            val cartQuantity = cartQuantities[packageItem.productInfoDomain.id] ?: 0
+            val isInCart = cartQuantity > 0
 
-                Product(
+            ReplenishProductUiModel(
+                product = Product(
                     id = packageItem.productInfoDomain.id,
                     name = packageItem.productInfoDomain.name,
                     description = packageItem.productInfoDomain.description,
@@ -48,7 +49,9 @@ class ReplenishItemsViewModel @Inject constructor(
                     price = packageItem.productInfoDomain.price,
                     isInCart = isInCart,
                     quantity = cartQuantity
-                )
-            }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+                ),
+                packageQuantity = packageItem.currentQuantity
+            )
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -212,6 +212,7 @@
     <string name="cart_payment_card">CARD</string>
 
     <string name="cart_product_available">Available: %1$d</string>
+    <string name="replenish_product_stock">Stock: %1$s</string>
     <string name="cart_product_add_to_cart">Add to cart</string>
     <string name="cart_product_increase_quantity">Increase quantity</string>
     <string name="cart_product_decrease_quantity">Decrease quantity</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Chaika</string>
+    <string name="action_next">NEXT</string>
     <string name="hint_product_search">Search by name</string>
 
     <string name="search">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,6 +225,7 @@
     <string name="cart_payment_card">КАРТА</string>
 
     <string name="cart_product_available">Доступно: %1$d</string>
+    <string name="replenish_product_stock">Остаток: %1$s</string>
     <string name="cart_product_add_to_cart">Добавить в корзину</string>
     <string name="cart_product_increase_quantity">Увеличить количество</string>
     <string name="cart_product_decrease_quantity">Уменьшить количество</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">Chaika</string>
+    <string name="action_next">ДАЛЕЕ</string>
     <string name="hint_product_search">Поиск по названию</string>
 
     <string name="search">Поиск</string>

--- a/app/src/test/java/com/chaikasoft/app/ui/viewmodels/ReplenishItemsViewModelTest.kt
+++ b/app/src/test/java/com/chaikasoft/app/ui/viewmodels/ReplenishItemsViewModelTest.kt
@@ -45,19 +45,24 @@ class ReplenishItemsViewModelTest : FunSpec({
         runTest {
             val p1 = productInfo(id = 1, name = "Tea")
             val p2 = productInfo(id = 2, name = "Coffee")
-            packageFlow.value = listOf(packageItem(product = p1), packageItem(product = p2))
+            packageFlow.value = listOf(
+                packageItem(product = p1, quantity = 12),
+                packageItem(product = p2, quantity = 4)
+            )
             cartFlow.value = listOf(cartItem(product = p1, quantity = 3))
 
             val display = vm.getDisplayProducts(cartFlow)
             display.test {
                 val first = awaitItem()
-                val tea = first.first { it.id == 1 }
-                val coffee = first.first { it.id == 2 }
+                val tea = first.first { it.product.id == 1 }
+                val coffee = first.first { it.product.id == 2 }
 
-                tea.isInCart shouldBe true
-                tea.quantity shouldBe 3
-                coffee.isInCart shouldBe false
-                coffee.quantity shouldBe 0
+                tea.product.isInCart shouldBe true
+                tea.product.quantity shouldBe 3
+                tea.packageQuantity shouldBe 12
+                coffee.product.isInCart shouldBe false
+                coffee.product.quantity shouldBe 0
+                coffee.packageQuantity shouldBe 4
             }
         }
     }


### PR DESCRIPTION
- Добавлен правый отступ для кнопки «+» и селектора количества на экранах редактирования шаблона и добора.
- Убраны затронутые хардкоды .dp в пользу ProductDimens.
- Для обоих экранов выделены чистые Content-компоненты и добавлены Compose Preview.
- Исправлено падение поиска в TemplateEditView: Paging-список теперь использует itemKey, устойчивый к обновлению результатов.
- Исправлен расчёт остатка при доборе: исходное количество и добавляемое количество передаются согласованно через ReplenishProductUiModel; лишний PackageViewModel удалён из экрана.
- Обновлён тест ReplenishItemsViewModel.
- Строки «ДАЛЕЕ» и «Остаток» локализованы для русского и английского языков; поиск использует существующий строковый ресурс.
- Сопутствующие сигнатуры и навигационный граф адаптированы к новым контрактам.